### PR TITLE
Enhanced Compatibility and Bug Fixes for Powwow and JMC

### DIFF
--- a/docs/layouts/doc-layout.html
+++ b/docs/layouts/doc-layout.html
@@ -5,7 +5,7 @@
     <title><!-- __TITLE__ --> | TinTin++ Script Converter</title>
     <meta name="description" content="<!-- __DESCRIPTION__ -->">
     <meta name="keywords" content="<!-- __KEYWORDS__ -->">
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
 </head>
 <body class="bg-gray-900 text-gray-200 antialiased">
 

--- a/docs/partials/navbar.html
+++ b/docs/partials/navbar.html
@@ -2,23 +2,23 @@
     <div class="container mx-auto px-4 md:px-8">
         <div class="flex items-center justify-between h-16">
             <div class="flex items-center space-x-4">
-                <a href="/index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
+                <a href="./index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
                     <span class="text-2xl">⚡</span>
                     <span class="hidden sm:inline">TT++ Converter</span>
                 </a>
                 <div class="hidden lg:flex space-x-4">
-                    <a href="/index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
+                    <a href="./index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
                     <div class="relative group">
                         <button class="text-gray-300 group-hover:text-white px-3 py-2 rounded-md text-sm font-medium inline-flex items-center">
                             Documentation
                             <svg class="ml-1 h-4 w-4 fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
                         </button>
                         <div class="absolute hidden group-hover:block w-48 bg-gray-800 border border-gray-700 rounded-md shadow-lg py-1 mt-0">
-                            <a href="/powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
-                            <a href="/jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
+                            <a href="./powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
+                            <a href="./jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
                             <div class="border-t border-gray-700 my-1"></div>
-                            <a href="/tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
-                            <a href="/tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
+                            <a href="./tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
+                            <a href="./tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
                         </div>
                     </div>
                 </div>

--- a/docs/src/tintinplusplus_help.md
+++ b/docs/src/tintinplusplus_help.md
@@ -10,7 +10,7 @@
 
 
 </span><span style='color:#FF5'>        ╭──────────────────────────────────────────────────────────────────────╮
-│                                 <a href='/index.html'>Home</a>                                 │
+│                                 <a href='./index.html'>Home</a>                                 │
 ╰──────────────────────────────────────────────────────────────────────╯
 
 <a href='#ACTION'>ACTION          </a>  <a href='#EDITING'>EDITING         </a>  <a href='#LOG'>LOG             </a>  <a href='#SCREEN'>SCREEN          </a>

--- a/docs/src/tintinplusplus_tutorial.md
+++ b/docs/src/tintinplusplus_tutorial.md
@@ -10,7 +10,7 @@
 
 
 </span><span style='color:#FF5'>        ╭──────────────────────────────────────────────────────────────────────╮
-│                                 <a href='/index.html'>Home</a>                                 │
+│                                 <a href='./index.html'>Home</a>                                 │
 ╰──────────────────────────────────────────────────────────────────────╯
 
 <a href='#INDEX'>INDEX           </a>  <a href='#GREETING'>GREETING        </a>  <a href='#MSDP'>MSDP            </a>  <a href='#STATEMENTS'>STATEMENTS      </a>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- __META__ -->
     <title><!-- __TITLE__ --> | TinTin++ Script Converter</title>
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -182,6 +182,6 @@
         </section>
     </div>
 
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -161,13 +161,13 @@
                             <div class="grid grid-cols-2 gap-4 text-sm">
                                 <div class="flex flex-col space-y-2">
                                     <span class="text-gray-500 font-semibold uppercase text-[10px]">Legacy Clients</span>
-                                    <a href="powwow.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">Powwow Help</a>
-                                    <a href="jmc_help.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">JMC Help</a>
+                                    <a href="./powwow.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">Powwow Help</a>
+                                    <a href="./jmc_help.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">JMC Help</a>
                                 </div>
                                 <div class="flex flex-col space-y-2">
                                     <span class="text-gray-500 font-semibold uppercase text-[10px]">TinTin++</span>
-                                    <a href="tintinplusplus_help.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">TT++ Help</a>
-                                    <a href="tintinplusplus_tutorial.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">TT++ Tutorial</a>
+                                    <a href="./tintinplusplus_help.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">TT++ Help</a>
+                                    <a href="./tintinplusplus_tutorial.html" class="text-cyan-400 hover:text-orange-400 transition underline decoration-cyan-800">TT++ Tutorial</a>
                                 </div>
                             </div>
                             <div class="mt-6 pt-6 border-t border-gray-800">

--- a/jmc_help.html
+++ b/jmc_help.html
@@ -27,23 +27,23 @@
     <div class="container mx-auto px-4 md:px-8">
         <div class="flex items-center justify-between h-16">
             <div class="flex items-center space-x-4">
-                <a href="/index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
+                <a href="./index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
                     <span class="text-2xl">⚡</span>
                     <span class="hidden sm:inline">TT++ Converter</span>
                 </a>
                 <div class="hidden lg:flex space-x-4">
-                    <a href="/index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
+                    <a href="./index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
                     <div class="relative group">
                         <button class="text-gray-300 group-hover:text-white px-3 py-2 rounded-md text-sm font-medium inline-flex items-center">
                             Documentation
                             <svg class="ml-1 h-4 w-4 fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
                         </button>
                         <div class="absolute hidden group-hover:block w-48 bg-gray-800 border border-gray-700 rounded-md shadow-lg py-1 mt-0">
-                            <a href="/powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
-                            <a href="/jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
+                            <a href="./powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
+                            <a href="./jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
                             <div class="border-t border-gray-700 my-1"></div>
-                            <a href="/tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
-                            <a href="/tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
+                            <a href="./tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
+                            <a href="./tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
                         </div>
                     </div>
                 </div>

--- a/jmc_help.html
+++ b/jmc_help.html
@@ -19,7 +19,7 @@
     <title>JMC Help | TinTin++ Script Converter</title>
     <meta name="description" content="Documentation for JMC Help in TinTin++ Script Converter">
     <meta name="keywords" content="TinTin++, MUD, JMC Help, migration, converter">
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
 </head>
 <body class="bg-gray-900 text-gray-200 antialiased">
 

--- a/powwow.html
+++ b/powwow.html
@@ -19,7 +19,7 @@
     <title>Powwow Help | TinTin++ Script Converter</title>
     <meta name="description" content="Documentation for Powwow Help in TinTin++ Script Converter">
     <meta name="keywords" content="TinTin++, MUD, Powwow Help, migration, converter">
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
 </head>
 <body class="bg-gray-900 text-gray-200 antialiased">
 

--- a/powwow.html
+++ b/powwow.html
@@ -27,23 +27,23 @@
     <div class="container mx-auto px-4 md:px-8">
         <div class="flex items-center justify-between h-16">
             <div class="flex items-center space-x-4">
-                <a href="/index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
+                <a href="./index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
                     <span class="text-2xl">⚡</span>
                     <span class="hidden sm:inline">TT++ Converter</span>
                 </a>
                 <div class="hidden lg:flex space-x-4">
-                    <a href="/index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
+                    <a href="./index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
                     <div class="relative group">
                         <button class="text-gray-300 group-hover:text-white px-3 py-2 rounded-md text-sm font-medium inline-flex items-center">
                             Documentation
                             <svg class="ml-1 h-4 w-4 fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
                         </button>
                         <div class="absolute hidden group-hover:block w-48 bg-gray-800 border border-gray-700 rounded-md shadow-lg py-1 mt-0">
-                            <a href="/powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
-                            <a href="/jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
+                            <a href="./powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
+                            <a href="./jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
                             <div class="border-t border-gray-700 my-1"></div>
-                            <a href="/tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
-                            <a href="/tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
+                            <a href="./tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
+                            <a href="./tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
                         </div>
                     </div>
                 </div>

--- a/src/converter.js
+++ b/src/converter.js
@@ -118,6 +118,7 @@ export class TinTinConverter {
     convertVarName(name) {
         const prefix = this.mode === 'jmc' ? 'j_' : 'p_';
         const arrayPrefix = this.mode === 'jmc' ? 'jmc' : 'powwow';
+        const namedPrefix = this.mode === 'jmc' ? 'j_' : 'p_';
 
         if (name.startsWith('@')) {
             const numMatch = name.match(/^@(-?\d+)$/);
@@ -125,14 +126,14 @@ export class TinTinConverter {
                 const n = numMatch[1];
                 return n.startsWith('-') ? `${prefix}at_m${n.substring(1)}` : `${arrayPrefix}_at[${n}]`;
             }
-            return prefix + 'at_' + name.substring(1);
+            return `${arrayPrefix}_at_${name.substring(1)}`;
         } else if (name.startsWith('$')) {
             const numMatch = name.match(/^\$(-?\d+)$/);
             if (numMatch) {
                 const n = numMatch[1];
                 return n.startsWith('-') ? `${prefix}dollar_m${n.substring(1)}` : `${arrayPrefix}_dollar[${n}]`;
             }
-            return prefix + name.substring(1);
+            return `${namedPrefix}${name.substring(1)}`;
         }
         return prefix + name;
     }
@@ -145,21 +146,24 @@ export class TinTinConverter {
 
             // 2. Named parameters/variables in ${var} or #{expr}
             str = str.replace(/\${([a-zA-Z0-9_-]+)}/g, (match, name) => {
-                return `$p_${name}`;
+                return `__VAR__p_${name}`;
             });
             str = str.replace(/#{([^}]+)}/g, (match, expr) => {
                 return `\$math_eval{${this.convertSyntax('(' + expr + ')')}}`;
             });
 
             // 3. Variables:
-            str = str.replace(/@([a-zA-Z_]\w*)/g, (match, name) => `\$${this.convertVarName('@' + name)}`);
-            str = str.replace(/@(\d+)/g, (match, num) => `\$${this.convertVarName('@' + num)}`);
+            str = str.replace(/@([a-zA-Z_]\w*)/g, (match, name) => `__VAR__${this.convertVarName('@' + name)}`);
+            str = str.replace(/@(\d+)/g, (match, num) => `__VAR__${this.convertVarName('@' + num)}`);
 
-            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w+)/g, (match, name) => `\$${this.convertVarName('$' + name)}`);
+            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w+)/g, (match, name) => `__VAR__${this.convertVarName('$' + name)}`);
 
             // 4. Standard parameters: $N -> %N, &N -> %N
             str = str.replace(/(?<!\\)\$(\d+)/g, '%$1');
             str = str.replace(/(?<!\\)&(\d+)/g, '%$1');
+
+            // Replace placeholders back with $ prefix
+            str = str.replace(/__VAR__/g, '$');
         } else if (this.mode === 'jmc') {
             // JMC uses %0-%9 for parameters and $var for variables
             // Standard parameters: %N -> %N (no change needed for TT++)
@@ -236,6 +240,10 @@ export class TinTinConverter {
     convertSingleCommand(line) {
         line = line.trim();
 
+        if (this.mode === 'powwow' && line.startsWith('#!')) {
+            return `#SYSTEM {${line.substring(2).trim()}}`;
+        }
+
         if (this.mode === 'powwow') {
             // Group toggle or label direct commands: #+label, #-label, #>label, #<label, #=label, #%label
             const toggleMatch = line.match(/^#\s*([<=>%+-])([\w_-]+)\s*$/);
@@ -282,8 +290,21 @@ export class TinTinConverter {
                 case 'ac':
                 case 'action':
                     return this.convertActionPowwow(args);
+                case 'setvar':
                 case 'var':
                     return this.convertVarPowwow(args);
+                case 'mark':
+                    return this.convertMarkPowwow(args);
+                case 'hilite':
+                    return `#HIGHLIGHT {.*} {${args}}`;
+                case 'beep':
+                    return `#BELL`;
+                case 'time':
+                    return `#FORMAT {powwow_at_time} {%t} {%Y-%m-%d %H:%M:%S}`;
+                case 'save':
+                    return `#WRITE {${args || 'converted.tin'}}`;
+                case 'load':
+                    return `#READ {${args || 'converted.tin'}}`;
                 case 'if':
                     return this.convertIfPowwow(args);
                 case 'while':
@@ -301,6 +322,12 @@ export class TinTinConverter {
                     return this.convertTickerPowwow(args, command);
                 case 'prompt':
                     return this.convertPromptPowwow(args);
+                case 'group':
+                    const pwGroupMatch = args.match(/^(\S+)\s+(on|off)/i);
+                    if (pwGroupMatch) {
+                        return pwGroupMatch[2].toLowerCase() === 'on' ? `#CLASS {${pwGroupMatch[1]}} {OPEN}` : `#CLASS {${pwGroupMatch[1]}} {KILL}`;
+                    }
+                    return `#COMMENT UNCONVERTED POWWOW GROUP: #group ${args}`;
                 case 'reset':
                     return this.convertReset(args);
                 case 'do':
@@ -313,6 +340,8 @@ export class TinTinConverter {
                     return `#COMMENT NICE (Priority) ignored: #nice ${args}`;
                 case 'identify':
                     return `#COMMENT IDENTIFY ignored: #identify ${args}`;
+                case '!':
+                    return `#SYSTEM {${args}}`;
                 case 'request':
                     return `#COMMENT REQUEST ignored: #request ${args}`;
                 case 'option':
@@ -349,6 +378,18 @@ export class TinTinConverter {
                 case 'sub':
                 case 'substitute':
                     return this.convertSubstituteJMC(args);
+                case 'antisubstitute':
+                case 'antisub':
+                    return `#ANTISUBSTITUTE {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
+                case 'unsubstitute':
+                case 'unsub':
+                    return `#UNSUB {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
+                case 'loop':
+                    return this.convertLoopJMC(args);
+                case 'tolower':
+                    return this.convertToLowerJMC(args);
+                case 'toupper':
+                    return this.convertToUpperJMC(args);
                 case 'unalias':
                     return `#UNALIAS {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
                 case 'unaction':
@@ -356,7 +397,17 @@ export class TinTinConverter {
                 case 'unvar':
                     return `#UNVAR {${this.convertVarName(this.cleanJMCArgs(args))}}`;
                 case 'showme':
-                    return `#SHOWME {${this.convertSyntax(args)}}`;
+                case 'output':
+                    return `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
+                case 'bell':
+                    return `#BELL`;
+                case 'break':
+                    return `#BREAK`;
+                case 'pathdir':
+                    return `#PATHDIR {${this.cleanJMCArgs(args)}}`;
+                case 'wait':
+                case 'wt':
+                    return `#DELAY {${this.cleanJMCArgs(args)}}`;
                 case 'echo':
                     if (args.toLowerCase() === 'on') return `#CONFIG {VERBOSE} {ON}`;
                     if (args.toLowerCase() === 'off') return `#CONFIG {VERBOSE} {OFF}`;
@@ -377,6 +428,10 @@ export class TinTinConverter {
                     return `#TEXTIN {${args}}`;
                 case 'systemexec':
                     return `#SYSTEM {${args}}`;
+                case 'speedwalk':
+                    if (args.toLowerCase() === 'on') return `#CONFIG {SPEEDWALK} {ON}`;
+                    if (args.toLowerCase() === 'off') return `#CONFIG {SPEEDWALK} {OFF}`;
+                    return `#COMMENT JMC SPEEDWALK: #speedwalk ${args}`;
                 case 'hotkey':
                     return this.convertHotkeyJMC(args);
                 case 'unhotkey':
@@ -396,6 +451,10 @@ export class TinTinConverter {
                     return args ? `#COMMENT UNCONVERTED DROP: #drop ${args}` : `#LINE GAG`;
                 case 'cr':
                     return `#SEND {\n}`;
+                case 'daa':
+                case 'hide':
+                case 'whisper':
+                    return `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`;
                 case 'bell':
                     return `#BELL`;
                 case 'ignore':
@@ -409,7 +468,7 @@ export class TinTinConverter {
     // --- Powwow Conversion Methods ---
 
     convertAliasPowwow(args) {
-        const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+)(?:@([\w_-]+))?\s+)?([^=]+)=(.+)/is);
+        const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+(?:[+-])?)(?:@([\w_-]+))?\s+)?([^=]+?)(?:@([\w_-]+))?=(.+)/is);
         if (!match) {
             if (args.trim() === '') return `#ALIAS`;
             const simpleMatch = args.match(/^([^=]+)=(.+)/is);
@@ -419,11 +478,11 @@ export class TinTinConverter {
             return `#comment UNCONVERTED ALIAS ARGS: ${args}`;
         }
 
-        const [, op, label, group, name, cmds] = match;
+        const [, op, label, group1, name, group2, cmds] = match;
         const convertedName = this.convertSubstitutions(name.trim());
         const convertedCmds = this.processCommands(cmds);
 
-        const targetClass = group || label;
+        const targetClass = group1 || group2 || label;
         let out = targetClass ? `#CLASS {${targetClass}} {OPEN}\n` : '';
         out += `#ALIAS {${convertedName}} {${convertedCmds}}`;
         if (targetClass) out += `\n#CLASS {${targetClass}} {CLOSE}`;
@@ -437,7 +496,7 @@ export class TinTinConverter {
             return op === '+' ? `#CLASS {${label}} {OPEN}` : `#CLASS {${label}} {KILL}`;
         }
 
-        const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+)(?:@([\w_-]+))?\s+)?([^=]+)=(.+)?/is);
+        const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+(?:[+-])?)(?:@([\w_-]+))?\s+)?([^=]+?)(?:@([\w_-]+))?=(.+)?/is);
         if (!match) {
              const simpleMatch = args.match(/^([^=]+)=(.+)?/is);
              if (simpleMatch) {
@@ -448,11 +507,11 @@ export class TinTinConverter {
              return `#comment UNCONVERTED ACTION ARGS: ${args}`;
         }
 
-        const [, op, label, group, pattern, cmds] = match;
+        const [, op, label, group1, pattern, group2, cmds] = match;
         const ttPattern = this.convertSyntax(pattern.trim());
         const ttCmds = cmds ? this.processCommands(cmds) : '';
 
-        const targetClass = group || label;
+        const targetClass = group1 || group2 || label;
         let out = targetClass ? `#CLASS {${targetClass}} {OPEN}\n` : '';
         if (ttCmds === '') {
             out += `#GAG {${ttPattern}}`;
@@ -566,6 +625,16 @@ export class TinTinConverter {
         return `#ACTION {${ttPattern}} {${ttCmds}; #line gag} {1}`;
     }
 
+    convertMarkPowwow(args) {
+        const match = args.match(/^([^=]+)(?:=(.*))?$/is);
+        if (match) {
+            const pattern = this.convertSyntax(match[1].trim());
+            const color = match[2] ? match[2].trim() : 'bold';
+            return `#HIGHLIGHT {${pattern}} {${color}}`;
+        }
+        return `#COMMENT UNCONVERTED MARK: #mark ${args}`;
+    }
+
     convertReset(args) {
         const type = args.toLowerCase().trim();
         if (type === 'alias' || type === 'aliases') return `#KILL ALIASES {*}*`;
@@ -653,13 +722,15 @@ export class TinTinConverter {
     }
 
     convertGroupJMC(args) {
-        // #group {enable|disable} {name}
-        const match = args.match(/^(enable|disable)\s+(\S+)/i);
+        // #group {enable|disable|list|delete|info|global|local} [name]
+        const match = args.match(/^(enable|disable|list|delete|info|global|local)(?:\s+(\S+))?/i);
         if (match) {
             const op = match[1].toLowerCase();
             const label = match[2];
             if (op === 'enable') return `#CLASS {${label}} {OPEN}`;
             if (op === 'disable') return `#CLASS {${label}} {KILL}`;
+            if (op === 'list') return `#CLASS`;
+            if (op === 'delete') return `#CLASS {${label}} {KILL}`;
         }
         return `#comment JMC GROUP COMMAND: #group ${args}`;
     }
@@ -703,6 +774,41 @@ export class TinTinConverter {
             return `#MACRO {${key}} {${this.processCommands(cmds)}}`;
         }
         return `#comment UNCONVERTED JMC HOTKEY: #hotkey ${args}`;
+    }
+
+    convertLoopJMC(args) {
+        // #loop {from,to[:delay]} {commands}
+        const match = args.match(/^{([^,]+),([^}:]+)(?::([^}]+))?}\s*{(.*)}$/s);
+        if (match) {
+            const from = match[1].trim();
+            const to = match[2].trim();
+            const cmds = match[4].trim();
+            // Protect $v from being prefixed by temporarily using a placeholder
+            const processed = this.processCommands(cmds.replace(/%0/g, '___V_VAR___'));
+            return `#LOOP {${from}} {${to}} {v} {${processed.replace(/___V_VAR___/g, '$v')}}`;
+        }
+        return `#COMMENT UNCONVERTED JMC LOOP: #loop ${args}`;
+    }
+
+    convertToLowerJMC(args) {
+        // #tolower {var} {text}
+        const match = args.match(/^{([^}]+)}\s*{(.*)}$/s) || args.match(/^(\S+)\s+(.*)$/s);
+        if (match) {
+            const varName = this.convertVarName(match[1].trim().replace(/^{|}$/g, ''));
+            const text = match[2].trim().replace(/^{|}$/g, '');
+            return `#FORMAT {${varName}} {%l} {${this.convertSyntax(text)}}`;
+        }
+        return `#COMMENT UNCONVERTED JMC TOLOWER: #tolower ${args}`;
+    }
+
+    convertToUpperJMC(args) {
+        const match = args.match(/^{([^}]+)}\s*{(.*)}$/s) || args.match(/^(\S+)\s+(.*)$/s);
+        if (match) {
+            const varName = this.convertVarName(match[1].trim().replace(/^{|}$/g, ''));
+            const text = match[2].trim().replace(/^{|}$/g, '');
+            return `#FORMAT {${varName}} {%u} {${this.convertSyntax(text)}}`;
+        }
+        return `#COMMENT UNCONVERTED JMC TOUPPER: #toupper ${args}`;
     }
 
     convert(inputScript) {

--- a/src/converter.js
+++ b/src/converter.js
@@ -6,6 +6,12 @@ export class TinTinConverter {
     constructor(options = {}) {
         this.separator = options.separator || ';';
         this.mode = options.mode || 'powwow'; // 'powwow' or 'jmc'
+        this.state = {
+            powwow: {
+                autoprint: false
+            }
+        };
+        this.initHandlers();
     }
 
     setSeparator(sep) {
@@ -17,6 +23,141 @@ export class TinTinConverter {
         if (this.mode === 'jmc') {
             this.separator = ';';
         }
+    }
+
+    initHandlers() {
+        this.powwowHandlers = {
+            'al': args => this.convertAliasPowwow(args),
+            'alias': args => this.convertAliasPowwow(args),
+            'ac': args => this.convertActionPowwow(args),
+            'action': args => this.convertActionPowwow(args),
+            'setvar': args => this.convertVarPowwow(args),
+            'var': args => this.convertVarPowwow(args),
+            'mark': args => this.convertMarkPowwow(args),
+            'hilite': args => `#HIGHLIGHT {.*} {${args}}`,
+            'beep': () => `#BELL`,
+            'time': () => `#FORMAT {powwow_at_time} {%t} {%Y-%m-%d %H:%M:%S}`,
+            'save': args => `#WRITE {${args || 'converted.tin'}}`,
+            'load': args => `#READ {${args || 'converted.tin'}}`,
+            'if': args => this.convertIfPowwow(args),
+            'while': args => this.convertWhilePowwow(args),
+            'for': args => this.convertForPowwow(args),
+            'print': args => args ? `#SHOWME {${this.convertSyntax(args)}}` : `#LINE PRINT`,
+            'send': args => {
+                if (args.startsWith('<')) return `#TEXTIN {${args.substring(1).trim()}}`;
+                if (args.startsWith('!')) return `#SYSTEM {${args.substring(1).trim()}}`;
+                return this.convertSyntax(args);
+            },
+            'in': args => this.convertTickerPowwow(args, 'in'),
+            'at': args => this.convertTickerPowwow(args, 'at'),
+            'prompt': args => this.convertPromptPowwow(args),
+            'group': args => {
+                const pwGroupMatch = args.match(/^(\S+)\s+(on|off)/i);
+                if (pwGroupMatch) {
+                    return pwGroupMatch[2].toLowerCase() === 'on' ? `#CLASS {${pwGroupMatch[1]}} {OPEN}` : `#CLASS {${pwGroupMatch[1]}} {KILL}`;
+                }
+                return `#COMMENT UNCONVERTED POWWOW GROUP: #group ${args}`;
+            },
+            'reset': args => this.convertReset(args),
+            'do': args => {
+                const doMatch = args.match(/^\((.*)\)\s*(.*)$/s);
+                if (doMatch) {
+                    return `#MATH {p_do_cnt} {${this.convertSyntax('(' + doMatch[1] + ')')}}; #$p_do_cnt {${this.processCommands(doMatch[2])}}`;
+                }
+                return `#COMMENT UNCONVERTED DO: #do ${args}`;
+            },
+            'nice': args => `#COMMENT NICE (Priority) ignored: #nice ${args}`,
+            'identify': args => `#COMMENT IDENTIFY ignored: #identify ${args}`,
+            '!': args => `#SYSTEM {${args}}`,
+            'request': args => `#COMMENT REQUEST ignored: #request ${args}`,
+            'option': args => {
+                const match = args.match(/^([+-])(\w+)/);
+                if (match) {
+                    const [, op, name] = match;
+                    if (name.toLowerCase() === 'autoprint') {
+                        this.state.powwow.autoprint = (op === '+');
+                        return `#COMMENT OPTION autoprint set to ${op === '+' ? 'ON' : 'OFF'}`;
+                    }
+                }
+                return `#COMMENT OPTION ignored: #option ${args}`;
+            },
+            'sep': args => {
+                this.setSeparator(args);
+                return `#COMMENT SEPARATOR set to ${args}`;
+            },
+            'quit': () => `#END`
+        };
+
+        this.jmcHandlers = {
+            'al': args => this.convertAliasJMC(args),
+            'alias': args => this.convertAliasJMC(args),
+            'ac': args => this.convertActionJMC(args),
+            'action': args => this.convertActionJMC(args),
+            'var': args => this.convertVarJMC(args),
+            'variable': args => this.convertVarJMC(args),
+            'if': args => this.convertIfJMC(args),
+            'math': args => this.convertMathJMC(args),
+            'group': args => this.convertGroupJMC(args),
+            'highlight': args => this.convertHighlightJMC(args),
+            'gag': args => this.convertGagJMC(args),
+            'sub': args => this.convertSubstituteJMC(args),
+            'substitute': args => this.convertSubstituteJMC(args),
+            'antisubstitute': args => `#ANTISUBSTITUTE {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'antisub': args => `#ANTISUBSTITUTE {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unsubstitute': args => `#UNSUB {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unsub': args => `#UNSUB {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'loop': args => this.convertLoopJMC(args),
+            'tolower': args => this.convertToLowerJMC(args),
+            'toupper': args => this.convertToUpperJMC(args),
+            'unalias': args => `#UNALIAS {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unaction': args => `#UNACT {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unvar': args => `#UNVAR {${this.convertVarName(this.cleanJMCArgs(args))}}`,
+            'showme': args => `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'output': args => `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'bell': () => `#BELL`,
+            'break': () => `#BREAK`,
+            'kickall': () => `#KILL ALL`,
+            'flash': () => `#BELL`,
+            'char': args => `#CONFIG {COMMAND_CHAR} {${this.cleanJMCArgs(args)}}`,
+            'pathdir': args => `#PATHDIR {${this.cleanJMCArgs(args)}}`,
+            'wait': args => `#DELAY {${this.cleanJMCArgs(args)}}`,
+            'wt': args => `#DELAY {${this.cleanJMCArgs(args)}}`,
+            'echo': args => {
+                if (args.toLowerCase() === 'on') return `#CONFIG {VERBOSE} {ON}`;
+                if (args.toLowerCase() === 'off') return `#CONFIG {VERBOSE} {OFF}`;
+                return `#SHOWME {${this.convertSyntax(args)}}`;
+            },
+            'quit': () => `#END`,
+            'zap': () => `#ZAP`,
+            'killall': () => `#KILL ALL`,
+            'read': args => `#READ {${args}}`,
+            'write': args => `#WRITE {${args}}`,
+            'log': args => `#LOG {${args}}`,
+            'textin': args => `#TEXTIN {${args}}`,
+            'systemexec': args => `#SYSTEM {${args}}`,
+            'speedwalk': args => {
+                if (args.toLowerCase() === 'on') return `#CONFIG {SPEEDWALK} {ON}`;
+                if (args.toLowerCase() === 'off') return `#CONFIG {SPEEDWALK} {OFF}`;
+                return `#COMMENT JMC SPEEDWALK: #speedwalk ${args}`;
+            },
+            'hotkey': args => this.convertHotkeyJMC(args),
+            'unhotkey': args => `#UNMACRO {${args}}`,
+            'message': args => {
+                if (args.toLowerCase().includes('off')) return `#CONFIG {VERBOSE} {OFF}`;
+                if (args.toLowerCase().includes('on')) return `#CONFIG {VERBOSE} {ON}`;
+                return `#COMMENT JMC MESSAGE: #message ${args}`;
+            },
+            'ticksize': args => `#VARIABLE {j_ticksize} {${args}}; #TICKER {jmc_tick} {#SHOWME #TICK} {${args}}`,
+            'tickon': () => `#TICKER {jmc_tick} {#SHOWME #TICK} {$j_ticksize}`,
+            'tickset': () => `#TICKER {jmc_tick} {#SHOWME #TICK} {$j_ticksize}`,
+            'tickoff': () => `#UNTICKER {jmc_tick}`,
+            'drop': args => args ? `#COMMENT UNCONVERTED DROP: #drop ${args}` : `#LINE GAG`,
+            'cr': () => `#SEND {\n}`,
+            'daa': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'hide': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'whisper': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'ignore': args => args ? `#IGNORE {${this.convertSyntax(this.cleanJMCArgs(args))}}` : `#IGNORE`
+        };
     }
 
     /**
@@ -283,185 +424,13 @@ export class TinTinConverter {
         let args = cmdMatch[2].trim();
 
         if (this.mode === 'powwow') {
-            switch (command) {
-                case 'al':
-                case 'alias':
-                    return this.convertAliasPowwow(args);
-                case 'ac':
-                case 'action':
-                    return this.convertActionPowwow(args);
-                case 'setvar':
-                case 'var':
-                    return this.convertVarPowwow(args);
-                case 'mark':
-                    return this.convertMarkPowwow(args);
-                case 'hilite':
-                    return `#HIGHLIGHT {.*} {${args}}`;
-                case 'beep':
-                    return `#BELL`;
-                case 'time':
-                    return `#FORMAT {powwow_at_time} {%t} {%Y-%m-%d %H:%M:%S}`;
-                case 'save':
-                    return `#WRITE {${args || 'converted.tin'}}`;
-                case 'load':
-                    return `#READ {${args || 'converted.tin'}}`;
-                case 'if':
-                    return this.convertIfPowwow(args);
-                case 'while':
-                    return this.convertWhilePowwow(args);
-                case 'for':
-                    return this.convertForPowwow(args);
-                case 'print':
-                    return `#SHOWME {${this.convertSyntax(args)}}`;
-                case 'send':
-                    if (args.startsWith('<')) return `#TEXTIN {${args.substring(1).trim()}}`;
-                    if (args.startsWith('!')) return `#SYSTEM {${args.substring(1).trim()}}`;
-                    return this.convertSyntax(args);
-                case 'in':
-                case 'at':
-                    return this.convertTickerPowwow(args, command);
-                case 'prompt':
-                    return this.convertPromptPowwow(args);
-                case 'group':
-                    const pwGroupMatch = args.match(/^(\S+)\s+(on|off)/i);
-                    if (pwGroupMatch) {
-                        return pwGroupMatch[2].toLowerCase() === 'on' ? `#CLASS {${pwGroupMatch[1]}} {OPEN}` : `#CLASS {${pwGroupMatch[1]}} {KILL}`;
-                    }
-                    return `#COMMENT UNCONVERTED POWWOW GROUP: #group ${args}`;
-                case 'reset':
-                    return this.convertReset(args);
-                case 'do':
-                    const doMatch = args.match(/^\((.*)\)\s*(.*)$/s);
-                    if (doMatch) {
-                        return `#MATH {p_do_cnt} {${this.convertSyntax('(' + doMatch[1] + ')')}}; #$p_do_cnt {${this.processCommands(doMatch[2])}}`;
-                    }
-                    return `#COMMENT UNCONVERTED DO: #do ${args}`;
-                case 'nice':
-                    return `#COMMENT NICE (Priority) ignored: #nice ${args}`;
-                case 'identify':
-                    return `#COMMENT IDENTIFY ignored: #identify ${args}`;
-                case '!':
-                    return `#SYSTEM {${args}}`;
-                case 'request':
-                    return `#COMMENT REQUEST ignored: #request ${args}`;
-                case 'option':
-                    return `#COMMENT OPTION ignored: #option ${args}`;
-                case 'sep':
-                    this.setSeparator(args);
-                    return `#COMMENT SEPARATOR set to ${args}`;
-                case 'quit':
-                    return `#END`;
-                default:
-                    return `#COMMENT UNSUPPORTED: ${line}`;
-            }
+            const handler = this.powwowHandlers[command];
+            if (handler) return handler(args);
+            return `#COMMENT UNSUPPORTED: ${line}`;
         } else if (this.mode === 'jmc') {
-            switch (command) {
-                case 'al':
-                case 'alias':
-                    return this.convertAliasJMC(args);
-                case 'ac':
-                case 'action':
-                    return this.convertActionJMC(args);
-                case 'var':
-                case 'variable':
-                    return this.convertVarJMC(args);
-                case 'if':
-                    return this.convertIfJMC(args);
-                case 'math':
-                    return this.convertMathJMC(args);
-                case 'group':
-                    return this.convertGroupJMC(args);
-                case 'highlight':
-                    return this.convertHighlightJMC(args);
-                case 'gag':
-                    return this.convertGagJMC(args);
-                case 'sub':
-                case 'substitute':
-                    return this.convertSubstituteJMC(args);
-                case 'antisubstitute':
-                case 'antisub':
-                    return `#ANTISUBSTITUTE {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
-                case 'unsubstitute':
-                case 'unsub':
-                    return `#UNSUB {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
-                case 'loop':
-                    return this.convertLoopJMC(args);
-                case 'tolower':
-                    return this.convertToLowerJMC(args);
-                case 'toupper':
-                    return this.convertToUpperJMC(args);
-                case 'unalias':
-                    return `#UNALIAS {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
-                case 'unaction':
-                    return `#UNACT {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
-                case 'unvar':
-                    return `#UNVAR {${this.convertVarName(this.cleanJMCArgs(args))}}`;
-                case 'showme':
-                case 'output':
-                    return `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`;
-                case 'bell':
-                    return `#BELL`;
-                case 'break':
-                    return `#BREAK`;
-                case 'pathdir':
-                    return `#PATHDIR {${this.cleanJMCArgs(args)}}`;
-                case 'wait':
-                case 'wt':
-                    return `#DELAY {${this.cleanJMCArgs(args)}}`;
-                case 'echo':
-                    if (args.toLowerCase() === 'on') return `#CONFIG {VERBOSE} {ON}`;
-                    if (args.toLowerCase() === 'off') return `#CONFIG {VERBOSE} {OFF}`;
-                    return `#SHOWME {${this.convertSyntax(args)}}`;
-                case 'quit':
-                    return `#END`;
-                case 'zap':
-                    return `#ZAP`;
-                case 'killall':
-                    return `#KILL ALL`;
-                case 'read':
-                    return `#READ {${args}}`;
-                case 'write':
-                    return `#WRITE {${args}}`;
-                case 'log':
-                    return `#LOG {${args}}`;
-                case 'textin':
-                    return `#TEXTIN {${args}}`;
-                case 'systemexec':
-                    return `#SYSTEM {${args}}`;
-                case 'speedwalk':
-                    if (args.toLowerCase() === 'on') return `#CONFIG {SPEEDWALK} {ON}`;
-                    if (args.toLowerCase() === 'off') return `#CONFIG {SPEEDWALK} {OFF}`;
-                    return `#COMMENT JMC SPEEDWALK: #speedwalk ${args}`;
-                case 'hotkey':
-                    return this.convertHotkeyJMC(args);
-                case 'unhotkey':
-                    return `#UNMACRO {${args}}`;
-                case 'message':
-                    if (args.toLowerCase().includes('off')) return `#CONFIG {VERBOSE} {OFF}`;
-                    if (args.toLowerCase().includes('on')) return `#CONFIG {VERBOSE} {ON}`;
-                    return `#COMMENT JMC MESSAGE: #message ${args}`;
-                case 'ticksize':
-                    return `#VARIABLE {j_ticksize} {${args}}; #TICKER {jmc_tick} {#SHOWME #TICK} {${args}}`;
-                case 'tickon':
-                case 'tickset':
-                    return `#TICKER {jmc_tick} {#SHOWME #TICK} {$j_ticksize}`;
-                case 'tickoff':
-                    return `#UNTICKER {jmc_tick}`;
-                case 'drop':
-                    return args ? `#COMMENT UNCONVERTED DROP: #drop ${args}` : `#LINE GAG`;
-                case 'cr':
-                    return `#SEND {\n}`;
-                case 'daa':
-                case 'hide':
-                case 'whisper':
-                    return `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`;
-                case 'bell':
-                    return `#BELL`;
-                case 'ignore':
-                    return args ? `#IGNORE {${this.convertSyntax(this.cleanJMCArgs(args))}}` : `#IGNORE`;
-                default:
-                    return `#${command.toUpperCase()} {${this.convertSyntax(args)}}`;
-            }
+            const handler = this.jmcHandlers[command];
+            if (handler) return handler(args);
+            return `#${command.toUpperCase()} {${this.convertSyntax(args)}}`;
         }
     }
 
@@ -501,22 +470,38 @@ export class TinTinConverter {
              const simpleMatch = args.match(/^([^=]+)=(.+)?/is);
              if (simpleMatch) {
                  const ttPattern = this.convertSyntax(simpleMatch[1].trim());
-                 const ttCmds = simpleMatch[2] ? this.processCommands(simpleMatch[2]) : '';
-                 return ttCmds === '' ? `#GAG {${ttPattern}}` : `#ACTION {${ttPattern}} {${ttCmds}}`;
+                 const rawCmds = simpleMatch[2] || '';
+                 const hasPrint = rawCmds.toLowerCase().includes('#print');
+                 const ttCmds = this.processCommands(rawCmds);
+
+                 if (rawCmds === '') return `#GAG {${ttPattern}}`;
+
+                 // In Powwow, #action intercepts GAG by default unless autoprint is ON or #print is called.
+                 if (this.state.powwow.autoprint || hasPrint) {
+                     return `#ACTION {${ttPattern}} {${ttCmds}}`;
+                 } else {
+                     return `#ACTION {${ttPattern}} {${ttCmds}; #LINE GAG}`;
+                 }
              }
              return `#comment UNCONVERTED ACTION ARGS: ${args}`;
         }
 
         const [, op, label, group1, pattern, group2, cmds] = match;
         const ttPattern = this.convertSyntax(pattern.trim());
-        const ttCmds = cmds ? this.processCommands(cmds) : '';
+        const rawCmds = cmds || '';
+        const hasPrint = rawCmds.toLowerCase().includes('#print');
+        const ttCmds = this.processCommands(rawCmds);
 
         const targetClass = group1 || group2 || label;
         let out = targetClass ? `#CLASS {${targetClass}} {OPEN}\n` : '';
-        if (ttCmds === '') {
+        if (rawCmds === '') {
             out += `#GAG {${ttPattern}}`;
         } else {
-            out += `#ACTION {${ttPattern}} {${ttCmds}}`;
+            if (this.state.powwow.autoprint || hasPrint) {
+                out += `#ACTION {${ttPattern}} {${ttCmds}}`;
+            } else {
+                out += `#ACTION {${ttPattern}} {${ttCmds}; #LINE GAG}`;
+            }
         }
         if (targetClass) out += `\n#CLASS {${targetClass}} {CLOSE}`;
         return out;

--- a/tests/converter.test.js
+++ b/tests/converter.test.js
@@ -10,10 +10,26 @@ describe('TinTinConverter - Powwow Mode', () => {
     expect(output).toContain('#ALIAS {ks} {kill %1}');
   });
 
-  it('converts simple action', () => {
+  it('converts simple action with default gag behavior', () => {
     const input = '#action ^You parry.=say Nice parry!';
     const output = converter.convert(input);
+    // In Powwow, actions gag by default.
+    expect(output).toContain('#ACTION {^You parry.} {say Nice parry!; #LINE GAG}');
+  });
+
+  it('converts action with #print (no gag)', () => {
+    const input = '#action ^You parry.={#print; say Nice parry!}';
+    const output = converter.convert(input);
+    expect(output).toContain('#ACTION {^You parry.} {#LINE PRINT; say Nice parry!}');
+    expect(output).not.toContain('#LINE GAG');
+  });
+
+  it('respects #option +autoprint', () => {
+    const input = '#option +autoprint\n#action ^You parry.=say Nice parry!';
+    const output = converter.convert(input);
+    expect(output).toContain('#COMMENT OPTION autoprint set to ON');
     expect(output).toContain('#ACTION {^You parry.} {say Nice parry!}');
+    expect(output).not.toContain('#LINE GAG');
   });
 
   it('handles custom separator', () => {
@@ -50,6 +66,14 @@ describe('TinTinConverter - Powwow Mode', () => {
     expect(output).toContain('#ALIAS {loot+}');
     expect(output).toContain('#MATH {powwow_at_loot_timer} {timer}');
     expect(output).not.toContain('$p_p_at');
+  });
+
+  it('handles Powwow alias with minus suffix and label', () => {
+    const input = '#alias loot-@autoloot={#action -loot1}';
+    const output = converter.convert(input);
+    expect(output).toContain('#CLASS {autoloot} {OPEN}');
+    expect(output).toContain('#ALIAS {loot-}');
+    expect(output).toContain('#CLASS {loot1} {KILL}');
   });
 
   it('correctly handles named parameters in ${var}', () => {

--- a/tests/converter.test.js
+++ b/tests/converter.test.js
@@ -39,6 +39,36 @@ describe('TinTinConverter - Powwow Mode', () => {
     expect(converter.convert('#in (1000) {say hello}')).toContain('#DELAY {1.00} {say hello}');
     expect(converter.convert('#at (5.5) {say hello}')).toContain('#DELAY {5.5} {say hello}');
   });
+
+  it('reproduces reported issue with loot+@autoloot', () => {
+    const input = '#alias loot+@autoloot={#action +loot1;#action +loot2;#(@loot_timer = timer)}';
+    const output = converter.convert(input);
+
+    // User clarified: alias name is "loot+" and class is "autoloot"
+
+    expect(output).toContain('#CLASS {autoloot} {OPEN}');
+    expect(output).toContain('#ALIAS {loot+}');
+    expect(output).toContain('#MATH {powwow_at_loot_timer} {timer}');
+    expect(output).not.toContain('$p_p_at');
+  });
+
+  it('correctly handles named parameters in ${var}', () => {
+    const input = '#alias test=say ${target} is dead';
+    const output = converter.convert(input);
+    expect(output).toContain('say $p_target is dead');
+    expect(output).not.toContain('$p_p_target');
+  });
+
+  it('converts Powwow #setvar, #mark, #hilite', () => {
+    expect(converter.convert('#setvar timer=100')).toContain('#VARIABLE {p_timer} {100}');
+    expect(converter.convert('#mark {Dragon}=bold red')).toContain('#HIGHLIGHT {{Dragon}} {bold red}');
+    expect(converter.convert('#hilite inverse')).toContain('#HIGHLIGHT {.*} {inverse}');
+    expect(converter.convert('#beep')).toContain('#BELL');
+    expect(converter.convert('#time')).toContain('#FORMAT {powwow_at_time}');
+    expect(converter.convert('#save my.tin')).toContain('#WRITE {my.tin}');
+    expect(converter.convert('#load my.tin')).toContain('#READ {my.tin}');
+    expect(converter.convert('#! ls')).toContain('#SYSTEM {ls}');
+  });
 });
 
 describe('TinTinConverter - JMC Mode', () => {
@@ -176,5 +206,25 @@ describe('TinTinConverter - JMC Mode', () => {
     expect(output).toContain('#UNALIAS {k}');
     expect(output).toContain('#UNACT {gag_line}');
     expect(output).toContain('#UNVAR {j_count}');
+  });
+
+  it('converts JMC #loop, #tolower, #toupper, #unsub', () => {
+    expect(converter.convert('#loop {1,5} {say %0}')).toContain('#LOOP {1} {5} {v} {say $v}');
+    expect(converter.convert('#tolower {target} {DRAGON}')).toContain('#FORMAT {j_target} {%l} {DRAGON}');
+    expect(converter.convert('#toupper {target} {dragon}')).toContain('#FORMAT {j_target} {%u} {dragon}');
+    expect(converter.convert('#unsub {foo}')).toContain('#UNSUB {foo}');
+  });
+
+  it('converts JMC #antisub and #speedwalk', () => {
+    expect(converter.convert('#antisub {safe line}')).toContain('#ANTISUBSTITUTE {safe line}');
+    expect(converter.convert('#speedwalk on')).toContain('#CONFIG {SPEEDWALK} {ON}');
+  });
+
+  it('converts more JMC commands: #bell, #break, #output, #pathdir, #wait', () => {
+    expect(converter.convert('#bell')).toContain('#BELL');
+    expect(converter.convert('#break')).toContain('#BREAK');
+    expect(converter.convert('#output {hello}')).toContain('#SHOWME {hello}');
+    expect(converter.convert('#pathdir {n} {s} {1}')).toContain('#PATHDIR {n} {s} {1}');
+    expect(converter.convert('#wait 1.5')).toContain('#DELAY {1.5}');
   });
 });

--- a/tintinplusplus_help.html
+++ b/tintinplusplus_help.html
@@ -27,23 +27,23 @@
     <div class="container mx-auto px-4 md:px-8">
         <div class="flex items-center justify-between h-16">
             <div class="flex items-center space-x-4">
-                <a href="/index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
+                <a href="./index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
                     <span class="text-2xl">⚡</span>
                     <span class="hidden sm:inline">TT++ Converter</span>
                 </a>
                 <div class="hidden lg:flex space-x-4">
-                    <a href="/index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
+                    <a href="./index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
                     <div class="relative group">
                         <button class="text-gray-300 group-hover:text-white px-3 py-2 rounded-md text-sm font-medium inline-flex items-center">
                             Documentation
                             <svg class="ml-1 h-4 w-4 fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
                         </button>
                         <div class="absolute hidden group-hover:block w-48 bg-gray-800 border border-gray-700 rounded-md shadow-lg py-1 mt-0">
-                            <a href="/powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
-                            <a href="/jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
+                            <a href="./powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
+                            <a href="./jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
                             <div class="border-t border-gray-700 my-1"></div>
-                            <a href="/tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
-                            <a href="/tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
+                            <a href="./tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
+                            <a href="./tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
                         </div>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
 <div class="terminal-container bg-black p-4 rounded-lg mb-8 overflow-x-auto font-mono text-sm leading-relaxed border border-gray-700 shadow-2xl">
 # TinTin++ Help
 <p></span><span style='color:#FF5'>        ╭──────────────────────────────────────────────────────────────────────╮
-│                                 <a href='/index.html'>Home</a>                                 │
+│                                 <a href='./index.html'>Home</a>                                 │
 ╰──────────────────────────────────────────────────────────────────────╯</p>
 <p><a href='#ACTION'>ACTION          </a>  <a href='#EDITING'>EDITING         </a>  <a href='#LOG'>LOG             </a>  <a href='#SCREEN'>SCREEN          </a>
 <a href='#ALIAS'>ALIAS           </a>  <a href='#ELSE'>ELSE            </a>  <a href='#LOOP'>LOOP            </a>  <a href='#SCREEN_READER'>SCREEN READER   </a>

--- a/tintinplusplus_help.html
+++ b/tintinplusplus_help.html
@@ -19,7 +19,7 @@
     <title>TinTin++ Help | TinTin++ Script Converter</title>
     <meta name="description" content="Documentation for TinTin++ Help in TinTin++ Script Converter">
     <meta name="keywords" content="TinTin++, MUD, TinTin++ Help, migration, converter">
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
 </head>
 <body class="bg-gray-900 text-gray-200 antialiased">
 

--- a/tintinplusplus_tutorial.html
+++ b/tintinplusplus_tutorial.html
@@ -27,23 +27,23 @@
     <div class="container mx-auto px-4 md:px-8">
         <div class="flex items-center justify-between h-16">
             <div class="flex items-center space-x-4">
-                <a href="/index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
+                <a href="./index.html" class="flex items-center space-x-2 text-cyan-400 font-bold text-xl">
                     <span class="text-2xl">⚡</span>
                     <span class="hidden sm:inline">TT++ Converter</span>
                 </a>
                 <div class="hidden lg:flex space-x-4">
-                    <a href="/index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
+                    <a href="./index.html" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Converter</a>
                     <div class="relative group">
                         <button class="text-gray-300 group-hover:text-white px-3 py-2 rounded-md text-sm font-medium inline-flex items-center">
                             Documentation
                             <svg class="ml-1 h-4 w-4 fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"/></svg>
                         </button>
                         <div class="absolute hidden group-hover:block w-48 bg-gray-800 border border-gray-700 rounded-md shadow-lg py-1 mt-0">
-                            <a href="/powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
-                            <a href="/jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
+                            <a href="./powwow.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">Powwow Help</a>
+                            <a href="./jmc_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">JMC Help</a>
                             <div class="border-t border-gray-700 my-1"></div>
-                            <a href="/tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
-                            <a href="/tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
+                            <a href="./tintinplusplus_help.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Help</a>
+                            <a href="./tintinplusplus_tutorial.html" class="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white">TinTin++ Tutorial</a>
                         </div>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
 <div class="terminal-container bg-black p-4 rounded-lg mb-8 overflow-x-auto font-mono text-sm leading-relaxed border border-gray-700 shadow-2xl">
 # TinTin++ Tutorial
 <p></span><span style='color:#FF5'>        ╭──────────────────────────────────────────────────────────────────────╮
-│                                 <a href='/index.html'>Home</a>                                 │
+│                                 <a href='./index.html'>Home</a>                                 │
 ╰──────────────────────────────────────────────────────────────────────╯</p>
 <p><a href='#INDEX'>INDEX           </a>  <a href='#GREETING'>GREETING        </a>  <a href='#MSDP'>MSDP            </a>  <a href='#STATEMENTS'>STATEMENTS      </a>
 <a href='#INTRODUCTION'>INTRODUCTION    </a>  <a href='#KEYPAD'>KEYPAD          </a>  <a href='#MSLP'>MSLP            </a>  <a href='#SUBSTITUTIONS'>SUBSTITUTIONS   </a>

--- a/tintinplusplus_tutorial.html
+++ b/tintinplusplus_tutorial.html
@@ -19,7 +19,7 @@
     <title>TinTin++ Tutorial | TinTin++ Script Converter</title>
     <meta name="description" content="Documentation for TinTin++ Tutorial in TinTin++ Script Converter">
     <meta name="keywords" content="TinTin++, MUD, TinTin++ Tutorial, migration, converter">
-    <link rel="stylesheet" href="/src/style.css">
+    <link rel="stylesheet" href="./src/style.css">
 </head>
 <body class="bg-gray-900 text-gray-200 antialiased">
 


### PR DESCRIPTION
This update significantly enhances the compatibility of the script converter for both Powwow and JMC clients. 

Key changes include:
- Refactored `convertSubstitutions` to prevent variables from being prefixed multiple times.
- Updated regex for Powwow aliases and actions to correctly extract groups/labels from constructs like `name@group` or `name+@group`.
- Implemented a wide range of common commands from the help files that were previously missing or only partially supported.
- Standardized navigation links across the site to use relative paths, ensuring they work correctly when hosted in subdirectories.
- Increased test coverage to ensure the reliability of the new conversion logic.

---
*PR created automatically by Jules for task [17413320065089584622](https://jules.google.com/task/17413320065089584622) started by @nschimme*