### PR TITLE
Improve Script Converter Compatibility with Lexer/Parser Refactor

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -205,16 +205,25 @@ class TinTinGenerator {
             outputLines.push('#FUNCTION {powwow_search} {#FORMAT {result} {%p} {%2} {%1}}');
         }
 
+        outputLines.push(this.generateNodes(nodes, '\n'));
+
+        outputLines.push('#CLASS {converted} {CLOSE}');
+        return outputLines.join('\n');
+    }
+
+    generateNodes(nodes, separator = '; ') {
+        let outputLines = [];
         let currentCommandNodes = [];
 
         const flush = () => {
             if (currentCommandNodes.length === 0) return;
-            const cmdStr = this.nodesToString(currentCommandNodes).trim();
-            if (cmdStr !== '') {
-                if (cmdStr.startsWith('#')) {
-                    outputLines.push(this.converter.convertSingleCommand(cmdStr));
+            const cmdStr = this.nodesToString(currentCommandNodes);
+            const trimmed = cmdStr.trim();
+            if (trimmed !== '') {
+                if (trimmed.startsWith('#')) {
+                    outputLines.push(this.converter.convertSingleCommand(trimmed).trim());
                 } else {
-                    outputLines.push(this.converter.convertSyntax(cmdStr));
+                    outputLines.push(this.converter.convertSyntax(cmdStr).trim());
                 }
             }
             currentCommandNodes = [];
@@ -222,7 +231,6 @@ class TinTinGenerator {
 
         for (let node of nodes) {
             if (node.type === 'Separator' || node.type === 'Pipe') {
-                // Special case for #sep command which takes the separator as an argument
                 const lastCmd = currentCommandNodes.filter(n => n.type === 'Command').pop();
                 if (lastCmd && lastCmd.value === '#sep') {
                     currentCommandNodes.push(node);
@@ -233,23 +241,28 @@ class TinTinGenerator {
                 flush();
             } else if (node.type === 'Comment') {
                 flush();
-                outputLines.push('#NOP ' + node.value.replace(/\/\/|\/\*|\*\/|##/g, '').trim());
+                const rawComment = node.value;
+                const cleanedComment = rawComment
+                    .replace(/^\s*(\/\/|##|\/\*)\s?/, '')
+                    .replace(/\s*\*\/\s*$/, '')
+                    .trim();
+                const commentLines = cleanedComment.split('\n');
+                commentLines.forEach(line => {
+                    outputLines.push('#NOP ' + line.trim());
+                });
             } else {
                 currentCommandNodes.push(node);
             }
         }
         flush();
-
-        outputLines.push('#CLASS {converted} {CLOSE}');
-        return outputLines.join('\n');
+        return outputLines.join(separator);
     }
 
     nodesToString(nodes) {
         return nodes.map(n => {
             if (n.type === 'BracedBlock') return '{' + this.nodesToString(n.content) + '}';
             if (n.type === 'ParenBlock') return '(' + this.nodesToString(n.content) + ')';
-            if (n.type === 'Comment') return ''; // Comments handled in generate
-            if (n.type === 'Newline') return '\n';
+            if (n.type === 'Comment') return n.value;
             return n.value || '';
         }).join('');
     }
@@ -569,7 +582,9 @@ export class TinTinConverter {
 
         // 3. Operators
         str = str.replace(/\brand\s+([@$a-zA-Z0-9_\[\]-]+|%\d+|\d+)/g, '@powwow_rand{$1}');
-        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):\?/g, '&$1[]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):\?/g, (match, v) => {
+            return `&${this.convertVarName(v)}[]`;
+        });
         str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.\?/g, '@powwow_char_length{$1}');
         str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1[$2]');
         str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1.char[$2]');
@@ -646,7 +661,7 @@ export class TinTinConverter {
             });
 
             // 3. Variables:
-            str = str.replace(/\\?@([a-zA-Z_]\w*)/g, (match, name) => {
+            str = str.replace(/\\?@([a-zA-Z_]\w+)/g, (match, name) => {
                 if (['powwow_timer', 'powwow_rand', 'powwow_char_length', 'powwow_search'].includes(name)) return `__FUNC__${name}`;
                 if (name.startsWith('powwow_') || name.startsWith('p_')) return `__VAR__${name}`;
                 return `__VAR__${this.convertVarName('@' + name)}`;
@@ -655,7 +670,7 @@ export class TinTinConverter {
 
             str = str.replace(/\${([a-zA-Z0-9_%$-]+)}/g, (match, name) => {
                 let res = name.replace(/\$(\d+)/g, '%$1');
-                res = res.replace(/\$([a-zA-Z_]\w*)/g, 'p_$1');
+                res = res.replace(/\$([a-zA-Z_]\w+)/g, 'p_$1');
                 if (!res.startsWith('p_') && !res.startsWith('%') && !res.startsWith('powwow_')) {
                     res = 'p_' + res;
                 }
@@ -676,18 +691,12 @@ export class TinTinConverter {
             str = str.replace(/__VAR__/g, '$');
             str = str.replace(/__FUNC__/g, '@');
 
-            // Final safety pass for Axel's script: ensure common variables like sessxp are prefixed
-            const common = ['sessxp', 'sesstp', 'gainxp', 'gaintp', 'oldxp', 'oldtp', 'xpcal'];
-            common.forEach(v => {
-                const reg = new RegExp('\\$'+v+'\\b', 'g');
-                str = str.replace(reg, '$p_'+v);
-            });
         } else if (this.mode === 'jmc') {
             // JMC uses %0-%9 for parameters and $var for variables
             // Standard parameters: %N -> %N (no change needed for TT++)
 
             // Variables: $var -> $j_var
-            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w*)/g, (match, name) => {
+            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w+)/g, (match, name) => {
                 if (name.startsWith('jmc_') || name.startsWith('j_')) return `\$${name}`;
                 return `\$${this.convertVarName(name)}`;
             });
@@ -724,34 +733,16 @@ export class TinTinConverter {
         if (!commandString) return '';
         let commandsStr = commandString.trim();
         if (commandsStr.startsWith('{') && commandsStr.endsWith('}')) {
-            commandsStr = commandsStr.substring(1, commandsStr.length - 1).trim();
+            commandsStr = commandsStr.substring(1, commandsStr.length - 1);
         }
         if (commandsStr === '') return '';
 
-        const tokens = this.tokenize(commandsStr);
-        const processed = [];
-        for (let i = 0; i < tokens.length; i++) {
-            let t = tokens[i].trim();
-            if (t === '') continue;
+        const lexer = new Lexer(commandsStr, { mode: this.mode, separator: this.separator });
+        const parser = new Parser(lexer);
+        const nodes = parser.parse();
 
-            if (t.toLowerCase().startsWith('#if')) {
-                // Peek for #else (Powwow specific or JMC if it follows that pattern)
-                if (this.mode === 'powwow') {
-                    if (i + 1 < tokens.length && tokens[i+1].trim().toLowerCase().startsWith('#else')) {
-                        t += '; ' + tokens[i+1].trim();
-                        i++;
-                    }
-                }
-            }
-
-            if (t.startsWith('#')) {
-                processed.push(this.convertSingleCommand(t));
-            } else {
-                processed.push(this.convertSyntax(t));
-            }
-        }
-
-        return processed.join('; ');
+        const generator = new TinTinGenerator(this);
+        return generator.generateNodes(nodes, '; ');
     }
 
     cleanJMCArgs(args) {
@@ -1034,8 +1025,15 @@ export class TinTinConverter {
             const seq = match[2];
             const cmd = match[3] || '';
             // We map Powwow bind to TinTin++ MACRO.
-            // Often name is something like 'f1' or 'Up'.
-            return `#MACRO {${name}} {${this.processCommands(cmd)}}`;
+            // If a key sequence is provided, prefer binding the MACRO to that
+            // sequence so that the original trigger semantics are preserved.
+            const macroKey = seq || name;
+            const processedCmd = this.processCommands(cmd);
+
+            // Preserve the original label as a comment if it differs from the sequence.
+            const labelComment = (seq && name && name !== seq) ? `#NOP ORIGINAL BIND LABEL: ${name}\n` : '';
+
+            return `${labelComment}#MACRO {${macroKey}} {${processedCmd}}`;
         }
         return `#NOP UNCONVERTED BIND: #bind ${args}`;
     }

--- a/src/converter.js
+++ b/src/converter.js
@@ -2,8 +2,262 @@
  * Robust Converter core logic for migrating to TinTin++
  */
 
+class Lexer {
+    constructor(input, options = {}) {
+        this.input = input;
+        this.pos = 0;
+        this.mode = options.mode || 'powwow';
+        this.separator = options.separator || ';';
+    }
+
+    peek() { return this.input[this.pos]; }
+
+    nextToken() {
+        if (this.pos >= this.input.length) return { type: 'EOF' };
+        let char = this.peek();
+
+        if (char === ' ' || char === '\t') {
+            let value = '';
+            while (this.pos < this.input.length && (this.input[this.pos] === ' ' || this.input[this.pos] === '\t')) {
+                value += this.input[this.pos++];
+            }
+            return { type: 'WHITESPACE', value };
+        }
+        if (char === '\n' || char === '\r') {
+             let value = '';
+             while (this.pos < this.input.length && (this.input[this.pos] === '\n' || this.input[this.pos] === '\r')) {
+                 value += this.input[this.pos++];
+             }
+             return { type: 'NEWLINE', value };
+        }
+
+        if (this.input.startsWith('//', this.pos)) {
+            let value = '';
+            while (this.pos < this.input.length && this.input[this.pos] !== '\n') {
+                value += this.input[this.pos++];
+            }
+            return { type: 'COMMENT', value };
+        }
+        if (this.input.startsWith('/*', this.pos)) {
+            let value = '/*';
+            this.pos += 2;
+            while (this.pos < this.input.length && !this.input.startsWith('*/', this.pos)) {
+                value += this.input[this.pos++];
+            }
+            if (this.input.startsWith('*/', this.pos)) {
+                value += '*/';
+                this.pos += 2;
+            }
+            return { type: 'COMMENT', value };
+        }
+        if (this.mode === 'jmc' && this.input.startsWith('##', this.pos)) {
+            let value = '';
+            while (this.pos < this.input.length && this.input[this.pos] !== '\n') {
+                value += this.input[this.pos++];
+            }
+            return { type: 'COMMENT', value };
+        }
+
+        if (char === '\\') {
+            this.pos++;
+            let next = this.input[this.pos++] || '';
+            return { type: 'TEXT', value: '\\' + next };
+        }
+
+        if (char === '{') { this.pos++; return { type: 'LBRACE' }; }
+        if (char === '}') { this.pos++; return { type: 'RBRACE' }; }
+        if (char === '(') { this.pos++; return { type: 'LPAREN' }; }
+        if (char === ')') { this.pos++; return { type: 'RPAREN' }; }
+        if (char === '"') {
+            let value = '"';
+            this.pos++;
+            while (this.pos < this.input.length) {
+                let c = this.input[this.pos++];
+                if (c === '\\') {
+                    value += c + (this.input[this.pos++] || '');
+                } else if (c === '"') {
+                    value += '"';
+                    break;
+                } else {
+                    value += c;
+                }
+            }
+            return { type: 'STRING', value };
+        }
+
+        if (char === this.separator) { this.pos++; return { type: 'SEPARATOR', value: char }; }
+        if (this.mode === 'powwow' && char === '|') { this.pos++; return { type: 'PIPE', value: char }; }
+
+        if (char === '#') {
+            let start = this.pos;
+            this.pos++;
+            let cmd = '#';
+            if (/[0-9]/.test(this.peek())) {
+                while (this.pos < this.input.length && /[0-9]/.test(this.input[this.pos])) {
+                    cmd += this.input[this.pos++];
+                }
+                return { type: 'COMMAND', value: cmd };
+            } else if (/[<=>%+-]/.test(this.peek())) {
+                cmd += this.input[this.pos++];
+                while (this.pos < this.input.length && /[\w_-]/.test(this.input[this.pos])) {
+                    cmd += this.input[this.pos++];
+                }
+                return { type: 'COMMAND', value: cmd };
+            } else if (this.peek() === '!') {
+                cmd += this.input[this.pos++];
+                return { type: 'COMMAND', value: cmd };
+            } else {
+                while (this.pos < this.input.length && /[\w_-]/.test(this.input[this.pos])) {
+                    cmd += this.input[this.pos++];
+                }
+                return { type: 'COMMAND', value: cmd };
+            }
+        }
+
+        let value = '';
+        while (this.pos < this.input.length) {
+            let c = this.input[this.pos];
+            if (/\s/.test(c) || '{}()";#|'.includes(c) || c === '\\') break;
+            if (this.input.startsWith('//', this.pos) || this.input.startsWith('/*', this.pos)) break;
+            value += c;
+            this.pos++;
+        }
+        if (value === '' && this.pos < this.input.length) {
+             value = this.input[this.pos++];
+        }
+        return { type: 'TEXT', value };
+    }
+}
+
+class Parser {
+    constructor(lexer) {
+        this.lexer = lexer;
+        this.tokens = [];
+        let t;
+        while ((t = this.lexer.nextToken()).type !== 'EOF') {
+            this.tokens.push(t);
+        }
+        this.pos = 0;
+    }
+
+    peek() { return this.tokens[this.pos] || { type: 'EOF' }; }
+    eat() { return this.tokens[this.pos++]; }
+
+    parse() {
+        return this.parseNodes();
+    }
+
+    parseNodes(until = []) {
+        let nodes = [];
+        while (this.pos < this.tokens.length) {
+            let t = this.peek();
+            if (until.includes(t.type)) break;
+
+            if (t.type === 'LBRACE') {
+                this.eat();
+                nodes.push({ type: 'BracedBlock', content: this.parseNodes(['RBRACE']) });
+                if (this.peek().type === 'RBRACE') this.eat();
+            } else if (t.type === 'LPAREN') {
+                this.eat();
+                nodes.push({ type: 'ParenBlock', content: this.parseNodes(['RPAREN']) });
+                if (this.peek().type === 'RPAREN') this.eat();
+            } else if (t.type === 'WHITESPACE') {
+                nodes.push({ type: 'Whitespace', value: this.eat().value });
+            } else if (t.type === 'NEWLINE') {
+                nodes.push({ type: 'Newline', value: this.eat().value });
+            } else if (t.type === 'COMMENT') {
+                nodes.push({ type: 'Comment', value: this.eat().value });
+            } else if (t.type === 'SEPARATOR') {
+                nodes.push({ type: 'Separator', value: this.eat().value });
+            } else if (t.type === 'PIPE') {
+                nodes.push({ type: 'Pipe', value: this.eat().value });
+            } else if (t.type === 'COMMAND') {
+                nodes.push({ type: 'Command', value: this.eat().value });
+            } else if (t.type === 'STRING') {
+                nodes.push({ type: 'String', value: this.eat().value });
+            } else {
+                nodes.push({ type: 'Text', value: this.eat().value });
+            }
+        }
+        return nodes;
+    }
+}
+
+class TinTinGenerator {
+    constructor(converter) {
+        this.converter = converter;
+        this.mode = converter.mode;
+    }
+
+    generate(nodes) {
+        let outputLines = [];
+        outputLines.push('#CLASS {converted} {OPEN}');
+
+        if (this.mode === 'powwow') {
+            outputLines.push('#NOP --- POWWOW COMPATIBILITY LAYER ---');
+            outputLines.push('#VARIABLE {powwow_at_lines} {24}');
+            outputLines.push('#VARIABLE {powwow_at_mem} {0}');
+            outputLines.push('#VARIABLE {powwow_at_buffer} {0}');
+            outputLines.push('#FORMAT {powwow_start_time} {%T}');
+            outputLines.push('#FUNCTION {powwow_timer} {#FORMAT {now} {%T};#MATH {result} {($now - $powwow_start_time) * 1000}}');
+            outputLines.push('#FUNCTION {powwow_rand} {#MATH {result} {1d%1 - 1}}');
+            outputLines.push('#FUNCTION {powwow_char_length} {#FORMAT {result} {%x} {%1}}');
+            outputLines.push('#FUNCTION {powwow_search} {#FORMAT {result} {%p} {%2} {%1}}');
+        }
+
+        let currentCommandNodes = [];
+
+        const flush = () => {
+            if (currentCommandNodes.length === 0) return;
+            const cmdStr = this.nodesToString(currentCommandNodes).trim();
+            if (cmdStr !== '') {
+                if (cmdStr.startsWith('#')) {
+                    outputLines.push(this.converter.convertSingleCommand(cmdStr));
+                } else {
+                    outputLines.push(this.converter.convertSyntax(cmdStr));
+                }
+            }
+            currentCommandNodes = [];
+        };
+
+        for (let node of nodes) {
+            if (node.type === 'Separator' || node.type === 'Pipe') {
+                // Special case for #sep command which takes the separator as an argument
+                const lastCmd = currentCommandNodes.filter(n => n.type === 'Command').pop();
+                if (lastCmd && lastCmd.value === '#sep') {
+                    currentCommandNodes.push(node);
+                    continue;
+                }
+                flush();
+            } else if (node.type === 'Newline') {
+                flush();
+            } else if (node.type === 'Comment') {
+                flush();
+                outputLines.push('#NOP ' + node.value.replace(/\/\/|\/\*|\*\/|##/g, '').trim());
+            } else {
+                currentCommandNodes.push(node);
+            }
+        }
+        flush();
+
+        outputLines.push('#CLASS {converted} {CLOSE}');
+        return outputLines.join('\n');
+    }
+
+    nodesToString(nodes) {
+        return nodes.map(n => {
+            if (n.type === 'BracedBlock') return '{' + this.nodesToString(n.content) + '}';
+            if (n.type === 'ParenBlock') return '(' + this.nodesToString(n.content) + ')';
+            if (n.type === 'Comment') return ''; // Comments handled in generate
+            if (n.type === 'Newline') return '\n';
+            return n.value || '';
+        }).join('');
+    }
+}
+
 export class TinTinConverter {
     constructor(options = {}) {
+        this.options = options;
         this.separator = options.separator || ';';
         this.mode = options.mode || 'powwow'; // 'powwow' or 'jmc'
         this.state = {
@@ -25,6 +279,36 @@ export class TinTinConverter {
         }
     }
 
+    extractBlock(str, openChar, closeChar) {
+        const trimmed = str.trim();
+        if (!trimmed || !trimmed.startsWith(openChar)) return null;
+
+        let depth = 0;
+        let inQuotes = false;
+        let escaped = false;
+        let startPos = str.indexOf(openChar);
+
+        for (let i = startPos; i < str.length; i++) {
+            const char = str[i];
+            if (escaped) { escaped = false; continue; }
+            if (char === '\\') { escaped = true; continue; }
+            if (char === '"') { inQuotes = !inQuotes; continue; }
+            if (inQuotes) continue;
+
+            if (char === openChar) depth++;
+            else if (char === closeChar) {
+                depth--;
+                if (depth === 0) {
+                    return {
+                        inner: str.substring(startPos + 1, i),
+                        rest: str.substring(i + 1)
+                    };
+                }
+            }
+        }
+        return null;
+    }
+
     initHandlers() {
         this.powwowHandlers = {
             'al': args => this.convertAliasPowwow(args),
@@ -36,6 +320,10 @@ export class TinTinConverter {
             'mark': args => this.convertMarkPowwow(args),
             'hilite': args => `#HIGHLIGHT {.*} {${args}}`,
             'beep': () => `#BELL`,
+            'bi': args => this.powwowHandlers['bind'](args),
+            'bind': args => this.convertBindPowwow(args),
+            'emu': args => this.powwowHandlers['emulate'](args),
+            'emulate': args => `#SHOWME {${this.convertSyntax(args)}}`,
             'time': () => `#FORMAT {powwow_at_time} {%t} {%Y-%m-%d %H:%M:%S}`,
             'save': args => `#WRITE {${args || 'converted.tin'}}`,
             'load': args => `#READ {${args || 'converted.tin'}}`,
@@ -56,7 +344,7 @@ export class TinTinConverter {
                 if (pwGroupMatch) {
                     return pwGroupMatch[2].toLowerCase() === 'on' ? `#CLASS {${pwGroupMatch[1]}} {OPEN}` : `#CLASS {${pwGroupMatch[1]}} {KILL}`;
                 }
-                return `#COMMENT UNCONVERTED POWWOW GROUP: #group ${args}`;
+                return `#NOP UNCONVERTED POWWOW GROUP: #group ${args}`;
             },
             'reset': args => this.convertReset(args),
             'do': args => {
@@ -64,28 +352,29 @@ export class TinTinConverter {
                 if (doMatch) {
                     return `#MATH {p_do_cnt} {${this.convertSyntax('(' + doMatch[1] + ')')}}; #$p_do_cnt {${this.processCommands(doMatch[2])}}`;
                 }
-                return `#COMMENT UNCONVERTED DO: #do ${args}`;
+                return `#NOP UNCONVERTED DO: #do ${args}`;
             },
-            'nice': args => `#COMMENT NICE (Priority) ignored: #nice ${args}`,
-            'identify': args => `#COMMENT IDENTIFY ignored: #identify ${args}`,
+            'nice': args => `#NOP NICE (Priority) ignored: #nice ${args}`,
+            'identify': args => `#NOP IDENTIFY ignored: #identify ${args}`,
             '!': args => `#SYSTEM {${args}}`,
-            'request': args => `#COMMENT REQUEST ignored: #request ${args}`,
+            'request': args => `#NOP REQUEST ignored: #request ${args}`,
             'option': args => {
                 const match = args.match(/^([+-])(\w+)/);
                 if (match) {
                     const [, op, name] = match;
                     if (name.toLowerCase() === 'autoprint') {
                         this.state.powwow.autoprint = (op === '+');
-                        return `#COMMENT OPTION autoprint set to ${op === '+' ? 'ON' : 'OFF'}`;
+                        return `#NOP OPTION autoprint set to ${op === '+' ? 'ON' : 'OFF'}`;
                     }
                 }
-                return `#COMMENT OPTION ignored: #option ${args}`;
+                return `#NOP OPTION ignored: #option ${args}`;
             },
             'sep': args => {
                 this.setSeparator(args);
-                return `#COMMENT SEPARATOR set to ${args}`;
+                return `#NOP SEPARATOR set to ${args}`;
             },
-            'quit': () => `#END`
+            'quit': () => `#END`,
+            'exe': args => this.processCommands(this.convertSyntax(args))
         };
 
         this.jmcHandlers = {
@@ -110,7 +399,9 @@ export class TinTinConverter {
             'tolower': args => this.convertToLowerJMC(args),
             'toupper': args => this.convertToUpperJMC(args),
             'unalias': args => `#UNALIAS {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unali': args => `#UNALIAS {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
             'unaction': args => `#UNACT {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
+            'unac': args => `#UNACT {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
             'unvar': args => `#UNVAR {${this.convertVarName(this.cleanJMCArgs(args))}}`,
             'showme': args => `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
             'output': args => `#SHOWME {${this.convertSyntax(this.cleanJMCArgs(args))}}`,
@@ -138,24 +429,53 @@ export class TinTinConverter {
             'speedwalk': args => {
                 if (args.toLowerCase() === 'on') return `#CONFIG {SPEEDWALK} {ON}`;
                 if (args.toLowerCase() === 'off') return `#CONFIG {SPEEDWALK} {OFF}`;
-                return `#COMMENT JMC SPEEDWALK: #speedwalk ${args}`;
+                return `#NOP JMC SPEEDWALK: #speedwalk ${args}`;
             },
             'hotkey': args => this.convertHotkeyJMC(args),
+            'hot': args => this.convertHotkeyJMC(args),
             'unhotkey': args => `#UNMACRO {${args}}`,
             'message': args => {
                 if (args.toLowerCase().includes('off')) return `#CONFIG {VERBOSE} {OFF}`;
                 if (args.toLowerCase().includes('on')) return `#CONFIG {VERBOSE} {ON}`;
-                return `#COMMENT JMC MESSAGE: #message ${args}`;
+                return `#NOP JMC MESSAGE: #message ${args}`;
             },
+            'multiaction': args => {
+                if (args.toLowerCase() === 'on') return `#NOP JMC MULTIACTION ON (TT++ default)`;
+                if (args.toLowerCase() === 'off') return `#NOP JMC MULTIACTION OFF (Not directly supported in TT++ without logic)`;
+                return `#NOP JMC MULTIACTION: #multiaction ${args}`;
+            },
+            'multihighlight': args => {
+                if (args.toLowerCase() === 'on') return `#NOP JMC MULTIHIGHLIGHT ON (TT++ default)`;
+                if (args.toLowerCase() === 'off') return `#NOP JMC MULTIHIGHLIGHT OFF (Not directly supported in TT++)`;
+                return `#NOP JMC MULTIHIGHLIGHT: #multihighlight ${args}`;
+            },
+            'presub': args => {
+                if (args.toLowerCase() === 'on') return `#NOP JMC PRESUB ON (Not directly supported in TT++)`;
+                if (args.toLowerCase() === 'off') return `#NOP JMC PRESUB OFF (TT++ default)`;
+                return `#NOP JMC PRESUB: #presub ${args}`;
+            },
+            'verbat': args => {
+                if (args.toLowerCase() === 'on') return `#CONFIG {VERBATIM} {ON}`;
+                if (args.toLowerCase() === 'off') return `#CONFIG {VERBATIM} {OFF}`;
+                return `#NOP JMC VERBAT: #verbat ${args}`;
+            },
+            'colon': args => {
+                return `#NOP JMC COLON: #colon ${args}`;
+            },
+            'comment': args => {
+                return `#NOP JMC COMMENT character set to: ${args}`;
+            },
+            'nop': args => `#NOP JMC NOP: ${args}`,
+            'script': args => `#NOP JMC SCRIPT (Internal logic needed): #script ${args}`,
             'ticksize': args => `#VARIABLE {j_ticksize} {${args}}; #TICKER {jmc_tick} {#SHOWME #TICK} {${args}}`,
             'tickon': () => `#TICKER {jmc_tick} {#SHOWME #TICK} {$j_ticksize}`,
             'tickset': () => `#TICKER {jmc_tick} {#SHOWME #TICK} {$j_ticksize}`,
             'tickoff': () => `#UNTICKER {jmc_tick}`,
-            'drop': args => args ? `#COMMENT UNCONVERTED DROP: #drop ${args}` : `#LINE GAG`,
+            'drop': args => args ? `#NOP UNCONVERTED DROP: #drop ${args}` : `#LINE GAG`,
             'cr': () => `#SEND {\n}`,
-            'daa': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
-            'hide': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
-            'whisper': args => `#COMMENT DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'daa': args => `#NOP DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'hide': args => `#NOP DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
+            'whisper': args => `#NOP DAA/HIDE/WHISPER (Secure send) partially supported: #SEND {${args}}`,
             'ignore': args => args ? `#IGNORE {${this.convertSyntax(this.cleanJMCArgs(args))}}` : `#IGNORE`
         };
     }
@@ -221,60 +541,95 @@ export class TinTinConverter {
      */
     convertSyntax(str) {
         if (this.mode === 'powwow') {
-            if (str.startsWith('(') && str.endsWith(')')) {
-                let inner = str.substring(1, str.length - 1).trim();
-                let result = this.processInlineFunctions(inner);
-                return this.convertSubstitutions(result);
+            const trimmed = str.trim();
+            if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
+                let inner = trimmed.substring(1, trimmed.length - 1).trim();
+                inner = this.evaluatePowwowExpression(inner);
+                return this.convertSubstitutions(inner);
             }
         }
 
         return this.convertSubstitutions(str);
     }
 
-    processInlineFunctions(str) {
-        // 1. Handle attr and noattr
+    evaluatePowwowExpression(str) {
+        // 1. Attributes
         str = str.replace(/attr\s*\("([^"]+)"\)/g, (match, attr) => this.mapAttributes(attr));
         str = str.replace(/attr\s+"([^"]+)"/g, (match, attr) => this.mapAttributes(attr));
-        str = str.replace(/noattr/g, '<099>');
+        str = str.replace(/\bnoattr\b/g, '<099>');
 
-        // 2. Concatenation
-        let lastStr;
-        do {
-            lastStr = str;
-            str = str.replace(/"([^"]*)"\s*\+\s*"([^"]*)"/g, '"$1$2"');
-            str = str.replace(/"([^"]*)"\s*\+\s*([@$][a-zA-Z0-9_-]+)/g, '"$1$2"');
-            str = str.replace(/([@$][a-zA-Z0-9_-]+)\s*\+\s*"([^"]*)"/g, '"$1$2"');
-            str = str.replace(/([@$][a-zA-Z0-9_-]+)\s*\+\s*([@$][a-zA-Z0-9_-]+)/g, '$1$2');
-            str = str.replace(/(<[0-9]+>)\s*\+\s*"([^"]*)"/g, '$1$2');
-            str = str.replace(/"([^"]*)"\s*\+\s*(<[0-9]+>)/g, '$1$2');
-            str = str.replace(/(<[0-9]+>)\s*\+\s*(<[0-9]+>)/g, '$1$2');
-            str = str.replace(/\s*\+\s*/g, '');
-        } while (str !== lastStr);
+        // 2. Keywords
+        str = str.replace(/\btimer\b/g, '@powwow_timer{}');
+        str = str.replace(/\bmap\b/g, '$powwow_at_map');
+        str = str.replace(/\bprompt\b/g, '$powwow_at_prompt');
+        str = str.replace(/\blast_line\b/g, '$powwow_at_last_line');
+        str = str.replace(/\bbuffer\b/g, '$powwow_at_buffer');
+        str = str.replace(/\blines\b/g, '$powwow_at_lines');
+        str = str.replace(/\bmem\b/g, '$powwow_at_mem');
 
-        str = str.replace(/^"/, '').replace(/"$/, '');
+        // 3. Operators
+        str = str.replace(/\brand\s+([@$a-zA-Z0-9_\[\]-]+|%\d+|\d+)/g, '@powwow_rand{$1}');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):\?/g, '&$1[]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.\?/g, '@powwow_char_length{$1}');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1[$2]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1.char[$2]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):>([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1[$2..-1]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+):<([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1[1..$2]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.>([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1.char[$2..-1]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\.<([@$a-zA-Z0-9_\[\]-]+|%\d+)/g, '$1.char[1..$2]');
+        str = str.replace(/([@$][a-zA-Z0-9_\[\]-]+|%\d+)\?([@$a-zA-Z0-9_\[\]-]+|%\d+|"[^"]*")/g, '@powwow_search{$1;$2}');
+
+        // Strip % conversion operator used in Axel's script
+        str = str.replace(/%\(([^)]+)\)/g, '$1');
+
+        // 4. Concatenation
+        if (str.includes('+')) {
+            let lastStr;
+            do {
+                lastStr = str;
+                str = str.replace(/"([^"]*)"\s*\+\s*"([^"]*)"/g, '"$1$2"');
+                str = str.replace(/"([^"]*)"\s*\+\s*([@$][a-zA-Z0-9_%-]+)/g, '"$1$2"');
+                str = str.replace(/([@$][a-zA-Z0-9_%-]+)\s*\+\s*"([^"]*)"/g, '"$1$2"');
+                str = str.replace(/([@$][a-zA-Z0-9_%-]+)\s*\+\s*([@$][a-zA-Z0-9_%-]+)/g, '$1$2');
+                str = str.replace(/(<[0-9]+>)\s*\+\s*"([^"]*)"/g, '$1$2');
+                str = str.replace(/"([^"]*)"\s*\+\s*(<[0-9]+>)/g, '$1$2');
+                str = str.replace(/(<[0-9]+>)\s*\+\s*(<[0-9]+>)/g, '$1$2');
+            } while (str !== lastStr);
+        }
 
         return str;
     }
 
     convertVarName(name) {
         const prefix = this.mode === 'jmc' ? 'j_' : 'p_';
-        const arrayPrefix = this.mode === 'jmc' ? 'jmc' : 'powwow';
-        const namedPrefix = this.mode === 'jmc' ? 'j_' : 'p_';
+
+        if (this.mode === 'jmc' && name.startsWith('$') && !name.match(/^\$\d+$/)) {
+            name = name.substring(1);
+        }
+
+        const specialPowwow = ['timer', 'map', 'prompt', 'last_line', 'buffer', 'lines', 'mem'];
+        if (this.mode === 'powwow' && specialPowwow.includes(name)) {
+            return `powwow_at_${name}`;
+        }
+        if (this.mode === 'powwow' && (name.startsWith('@') || name.startsWith('$'))) {
+            const inner = name.substring(1);
+            if (specialPowwow.includes(inner)) return `powwow_at_${inner}`;
+        }
 
         if (name.startsWith('@')) {
             const numMatch = name.match(/^@(-?\d+)$/);
             if (numMatch) {
                 const n = numMatch[1];
-                return n.startsWith('-') ? `${prefix}at_m${n.substring(1)}` : `${arrayPrefix}_at[${n}]`;
+                return n.startsWith('-') ? `powwow_at_m${n.substring(1)}` : `powwow_at[${n}]`;
             }
-            return `${arrayPrefix}_at_${name.substring(1)}`;
+            return `powwow_at_${name.substring(1)}`;
         } else if (name.startsWith('$')) {
             const numMatch = name.match(/^\$(-?\d+)$/);
             if (numMatch) {
                 const n = numMatch[1];
-                return n.startsWith('-') ? `${prefix}dollar_m${n.substring(1)}` : `${arrayPrefix}_dollar[${n}]`;
+                return n.startsWith('-') ? `${this.mode === 'jmc' ? 'jmc' : 'powwow'}_dollar_m${n.substring(1)}` : `${this.mode === 'jmc' ? 'jmc' : 'powwow'}_dollar[${n}]`;
             }
-            return `${namedPrefix}${name.substring(1)}`;
+            return `${prefix}${name.substring(1)}`;
         }
         return prefix + name;
     }
@@ -286,31 +641,56 @@ export class TinTinConverter {
             str = str.replace(/\\&(\d+)/g, '%%$1');
 
             // 2. Named parameters/variables in ${var} or #{expr}
-            str = str.replace(/\${([a-zA-Z0-9_-]+)}/g, (match, name) => {
-                return `__VAR__p_${name}`;
-            });
             str = str.replace(/#{([^}]+)}/g, (match, expr) => {
                 return `\$math_eval{${this.convertSyntax('(' + expr + ')')}}`;
             });
 
             // 3. Variables:
-            str = str.replace(/@([a-zA-Z_]\w*)/g, (match, name) => `__VAR__${this.convertVarName('@' + name)}`);
-            str = str.replace(/@(\d+)/g, (match, num) => `__VAR__${this.convertVarName('@' + num)}`);
+            str = str.replace(/\\?@([a-zA-Z_]\w*)/g, (match, name) => {
+                if (['powwow_timer', 'powwow_rand', 'powwow_char_length', 'powwow_search'].includes(name)) return `__FUNC__${name}`;
+                if (name.startsWith('powwow_') || name.startsWith('p_')) return `__VAR__${name}`;
+                return `__VAR__${this.convertVarName('@' + name)}`;
+            });
+            str = str.replace(/\\?@(-?\d+)/g, (match, num) => `__VAR__${this.convertVarName('@' + num)}`);
 
-            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w+)/g, (match, name) => `__VAR__${this.convertVarName('$' + name)}`);
+            str = str.replace(/\${([a-zA-Z0-9_%$-]+)}/g, (match, name) => {
+                let res = name.replace(/\$(\d+)/g, '%$1');
+                res = res.replace(/\$([a-zA-Z_]\w*)/g, 'p_$1');
+                if (!res.startsWith('p_') && !res.startsWith('%') && !res.startsWith('powwow_')) {
+                    res = 'p_' + res;
+                }
+                return `__VAR__${res}`;
+            });
+
+            str = str.replace(/(?<![%])\\?\$([a-zA-Z_]\w+)/g, (match, name) => {
+                if (name.startsWith('powwow_') || name.startsWith('p_')) return `__VAR__${name}`;
+                return `__VAR__${this.convertVarName('$' + name)}`;
+            });
+            str = str.replace(/(?<![%])\\?\$(-\d+)/g, (match, num) => `__VAR__${this.convertVarName('$' + num)}`);
 
             // 4. Standard parameters: $N -> %N, &N -> %N
-            str = str.replace(/(?<!\\)\$(\d+)/g, '%$1');
-            str = str.replace(/(?<!\\)&(\d+)/g, '%$1');
+            str = str.replace(/(?<![\\%])\$(\d+)/g, '%$1');
+            str = str.replace(/(?<![\\%])&(\d+)/g, '%$1');
 
-            // Replace placeholders back with $ prefix
+            // Replace placeholders back
             str = str.replace(/__VAR__/g, '$');
+            str = str.replace(/__FUNC__/g, '@');
+
+            // Final safety pass for Axel's script: ensure common variables like sessxp are prefixed
+            const common = ['sessxp', 'sesstp', 'gainxp', 'gaintp', 'oldxp', 'oldtp', 'xpcal'];
+            common.forEach(v => {
+                const reg = new RegExp('\\$'+v+'\\b', 'g');
+                str = str.replace(reg, '$p_'+v);
+            });
         } else if (this.mode === 'jmc') {
             // JMC uses %0-%9 for parameters and $var for variables
             // Standard parameters: %N -> %N (no change needed for TT++)
 
             // Variables: $var -> $j_var
-            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w*)/g, (match, name) => `\$${this.convertVarName(name)}`);
+            str = str.replace(/(?<![\\%])\$([a-zA-Z_]\w*)/g, (match, name) => {
+                if (name.startsWith('jmc_') || name.startsWith('j_')) return `\$${name}`;
+                return `\$${this.convertVarName(name)}`;
+            });
         }
 
         return str;
@@ -403,7 +783,11 @@ export class TinTinConverter {
                 const assignMatch = expr.match(/^([@$][a-zA-Z0-9_-]+)\s*=(.*)$/s);
                 if (assignMatch) {
                     const name = this.convertVarName(assignMatch[1]);
-                    return `#MATH {${name}} {${this.convertSyntax('(' + assignMatch[2].trim() + ')')}}`;
+                    const val = assignMatch[2].trim();
+                    if (val.startsWith('"')) {
+                        return `#VARIABLE {${name}} {${this.convertSyntax('(' + val + ')')}}`;
+                    }
+                    return `#MATH {${name}} {${this.convertSyntax('(' + val + ')')}}`;
                 }
                 return `#MATH {p_result} {${this.convertSyntax('(' + expr + ')')}}`;
             }
@@ -426,7 +810,7 @@ export class TinTinConverter {
         if (this.mode === 'powwow') {
             const handler = this.powwowHandlers[command];
             if (handler) return handler(args);
-            return `#COMMENT UNSUPPORTED: ${line}`;
+            return `#NOP UNSUPPORTED: ${line}`;
         } else if (this.mode === 'jmc') {
             const handler = this.jmcHandlers[command];
             if (handler) return handler(args);
@@ -444,7 +828,7 @@ export class TinTinConverter {
             if (simpleMatch) {
                 return `#ALIAS {${this.convertSubstitutions(simpleMatch[1].trim())}} {${this.processCommands(simpleMatch[2])}}`;
             }
-            return `#comment UNCONVERTED ALIAS ARGS: ${args}`;
+            return `#NOP UNCONVERTED ALIAS ARGS: ${args}`;
         }
 
         const [, op, label, group1, name, group2, cmds] = match;
@@ -480,10 +864,10 @@ export class TinTinConverter {
                  if (this.state.powwow.autoprint || hasPrint) {
                      return `#ACTION {${ttPattern}} {${ttCmds}}`;
                  } else {
-                     return `#ACTION {${ttPattern}} {${ttCmds}; #LINE GAG}`;
+                     return `#ACTION {${ttPattern}} {${ttCmds}${ttCmds ? '; ' : ''}#LINE GAG}`;
                  }
              }
-             return `#comment UNCONVERTED ACTION ARGS: ${args}`;
+             return `#NOP UNCONVERTED ACTION ARGS: ${args}`;
         }
 
         const [, op, label, group1, pattern, group2, cmds] = match;
@@ -500,7 +884,7 @@ export class TinTinConverter {
             if (this.state.powwow.autoprint || hasPrint) {
                 out += `#ACTION {${ttPattern}} {${ttCmds}}`;
             } else {
-                out += `#ACTION {${ttPattern}} {${ttCmds}; #LINE GAG}`;
+                out += `#ACTION {${ttPattern}} {${ttCmds}${ttCmds ? '; ' : ''}#LINE GAG}`;
             }
         }
         if (targetClass) out += `\n#CLASS {${targetClass}} {CLOSE}`;
@@ -516,15 +900,61 @@ export class TinTinConverter {
         let name = this.convertVarName(parts[0].trim());
         const val = parts[1].trim();
 
+        if (val.trim().startsWith('(')) {
+            let evaled = this.convertSyntax(val);
+            // If the evaluated expression looks like a string (contains quotes or color tags)
+            if (evaled.includes('"') || evaled.includes('<')) {
+                return `#VARIABLE {${name}} {${evaled.replace(/^"|"$/g, '')}}`;
+            }
+            return `#MATH {${name}} {${evaled}}`;
+        }
         return `#VARIABLE {${name}} {${this.processCommands(val)}}`;
     }
 
     convertIfPowwow(args) {
-        const match = args.match(/^\((.*)\)\s*(.*?)(?:\s*;\s*#else\s*(.*))?$/is);
-        if (!match) return `#comment UNCONVERTED IF: #if ${args}`;
+        const block = this.extractBlock(args, '(', ')');
+        if (!block) return `#NOP UNCONVERTED IF: #if ${args}`;
 
-        const [, cond, trueBlock, falseBlock] = match;
-        let out = `#IF {${this.convertSyntax('(' + cond + ')')}} {${this.processCommands(trueBlock)}}`;
+        const cond = block.inner;
+        let rest = block.rest.trim();
+        let trueBlock = '';
+        let falseBlock = '';
+
+        // Improved #else detection: look for #else that is NOT inside braces/parens
+        let elsePos = -1;
+        let depth = 0;
+        let inQuotes = false;
+        let escaped = false;
+        for (let i = 0; i < rest.length; i++) {
+            const char = rest[i];
+            if (escaped) { escaped = false; continue; }
+            if (char === '\\') { escaped = true; continue; }
+            if (char === '"') { inQuotes = !inQuotes; continue; }
+            if (inQuotes) continue;
+            if (char === '{' || char === '(') depth++;
+            else if (char === '}' || char === ')') depth--;
+            else if (depth === 0 && rest.substring(i).toLowerCase().startsWith('#else')) {
+                elsePos = i;
+                break;
+            }
+        }
+
+        if (elsePos !== -1) {
+            trueBlock = rest.substring(0, elsePos).trim();
+            // Strip trailing separator if present before #else
+            if (trueBlock.endsWith(';') || trueBlock.endsWith('|')) {
+                trueBlock = trueBlock.substring(0, trueBlock.length - 1).trim();
+            }
+            falseBlock = rest.substring(elsePos + 5).trim();
+            // If #else was #else {cmds}, strip braces
+            if (falseBlock.startsWith('{') && falseBlock.endsWith('}')) {
+                falseBlock = falseBlock.substring(1, falseBlock.length - 1).trim();
+            }
+        } else {
+            trueBlock = rest;
+        }
+
+        let out = `#IF {${this.convertSyntax('(' + cond + ')').replace(/\s*!=\s*/g, ' != ').replace(/\s*==\s*/g, ' == ')}} {${this.processCommands(trueBlock)}}`;
         if (falseBlock) {
             out += ` {#ELSE} {${this.processCommands(falseBlock)}}`;
         }
@@ -532,23 +962,28 @@ export class TinTinConverter {
     }
 
     convertWhilePowwow(args) {
-        const match = args.match(/^\((.*)\)\s*(.*)$/is);
-        if (!match) return `#comment UNCONVERTED WHILE: #while ${args}`;
-        const [, cond, block] = match;
-        return `#WHILE {${this.convertSyntax('(' + cond + ')')}} {${this.processCommands(block)}}`;
+        const block = this.extractBlock(args, '(', ')');
+        if (!block) return `#NOP UNCONVERTED WHILE: #while ${args}`;
+        return `#WHILE {${this.convertSyntax('(' + block.inner + ')')}} {${this.processCommands(block.rest)}}`;
     }
 
     convertForPowwow(args) {
-        const match = args.match(/^\(([^;]*);([^;]*);([^)]*)\)\s*(.*)$/is);
-        if (!match) return `#comment UNCONVERTED FOR: #for ${args}`;
-        const [, init, check, loop, block] = match;
+        const block = this.extractBlock(args, '(', ')');
+        if (!block) return `#NOP UNCONVERTED FOR: #for ${args}`;
+
+        const parts = block.inner.split(';');
+        if (parts.length < 3) return `#NOP INVALID FOR: #for (${block.inner}) ${block.rest}`;
+
+        const init = parts[0].trim();
+        const check = parts[1].trim();
+        const loop = parts[2].trim();
+        const body = block.rest.trim();
 
         let out = '';
-        if (init.trim()) {
-            const processedInit = this.convertSingleCommand(`#(${init.trim()})`);
-            out += `${processedInit}; `;
+        if (init) {
+            out += `${this.convertSingleCommand(`#(${init})`)}; `;
         }
-        out += `#WHILE {${this.convertSyntax('(' + check + ')')}} {${this.processCommands(block)}; ${this.convertSingleCommand(`#(${loop.trim()})`)}}`;
+        out += `#WHILE {${this.convertSyntax('(' + check + ')')}} {${this.processCommands(body)}; ${this.convertSingleCommand(`#(${loop})`)}}`;
         return out;
     }
 
@@ -579,7 +1014,7 @@ export class TinTinConverter {
         }
 
         const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+)(?:@([\w_-]+))?\s+)?([\w_-]+)\s*\((.*?)\)\s*(.*)/is);
-        if (!match) return `#comment UNCONVERTED TICKER ARGS: ${args}`;
+        if (!match) return `#NOP UNCONVERTED TICKER ARGS: ${args}`;
 
         const [, op, label, group, tickerName, delay, cmds] = match;
         const delayVal = isNaN(delay) ? this.convertSyntax('(' + delay + ')') : (parseInt(delay) / 1000).toFixed(2);
@@ -591,6 +1026,20 @@ export class TinTinConverter {
         return out;
     }
 
+    convertBindPowwow(args) {
+        // #bind name [sequence][=[command]]
+        const match = args.match(/^([^= ]+)(?:\s+([^= ]+))?(?:=(.*))?$/s);
+        if (match) {
+            const name = match[1];
+            const seq = match[2];
+            const cmd = match[3] || '';
+            // We map Powwow bind to TinTin++ MACRO.
+            // Often name is something like 'f1' or 'Up'.
+            return `#MACRO {${name}} {${this.processCommands(cmd)}}`;
+        }
+        return `#NOP UNCONVERTED BIND: #bind ${args}`;
+    }
+
     convertPromptPowwow(args) {
         const match = args.match(/^(?:([<=>%][+-]?)?([\w_-]+)(?:@([\w_-]+))?\s+)?([^=]+)=(.+)?/is);
         if (!match) {
@@ -598,16 +1047,16 @@ export class TinTinConverter {
              if (simpleMatch) {
                  const ttPattern = this.convertSyntax(simpleMatch[1].trim());
                  const ttCmds = simpleMatch[2] ? this.processCommands(simpleMatch[2]) : '';
-                 return `#ACTION {${ttPattern}} {${ttCmds}; #line gag} {1}`;
+                 return `#PROMPT {${ttPattern}} {${ttCmds}}`;
              }
-             return `#comment UNCONVERTED PROMPT ARGS: ${args}`;
+             return `#NOP UNCONVERTED PROMPT ARGS: ${args}`;
         }
         const [, op, label, group, pattern, cmds] = match;
 
         const ttPattern = this.convertSyntax(pattern.trim());
         const ttCmds = cmds ? this.processCommands(cmds) : '';
 
-        return `#ACTION {${ttPattern}} {${ttCmds}; #line gag} {1}`;
+        return `#PROMPT {${ttPattern}} {${ttCmds}}`;
     }
 
     convertMarkPowwow(args) {
@@ -617,7 +1066,7 @@ export class TinTinConverter {
             const color = match[2] ? match[2].trim() : 'bold';
             return `#HIGHLIGHT {${pattern}} {${color}}`;
         }
-        return `#COMMENT UNCONVERTED MARK: #mark ${args}`;
+        return `#NOP UNCONVERTED MARK: #mark ${args}`;
     }
 
     convertReset(args) {
@@ -629,33 +1078,82 @@ export class TinTinConverter {
         if (type === 'at' || type === 'in' || type === 'ticker' || type === 'tickers') return `#KILL TICKERS {*}*`;
         if (type === 'bind' || type === 'binds' || type === 'key') return `#KILL MACROS {*}*`;
         if (type === 'all') {
-            return `#KILL ALIASES {*}*; #KILL ACTIONS {*}*; #KILL VARIABLES {*}*; #KILL HIGHLIGHTS {*}*; #KILL TICKERS {*}*; #KILL MACROS {*}*; #COMMENT --- RESET ALL ---`;
+            return `#KILL ALIASES {*}*; #KILL ACTIONS {*}*; #KILL VARIABLES {*}*; #KILL HIGHLIGHTS {*}*; #KILL TICKERS {*}*; #KILL MACROS {*}*; #NOP --- RESET ALL ---`;
         }
-        return `#comment UNCONVERTED RESET: #reset ${args}`;
+        return `#NOP UNCONVERTED RESET: #reset ${args}`;
     }
 
     // --- JMC Conversion Methods ---
 
     convertAliasJMC(args) {
-        // #alias {name} {commands}
-        const match = args.match(/^{([^}]+)}\s*{(.*)}$/s) || args.match(/^(\S+)\s+(.*)$/s);
-        if (match) {
-            const name = match[1].trim().replace(/^{|}$/g, '');
-            const cmds = match[2].trim().replace(/^{|}$/g, '');
-            return `#ALIAS {${this.convertSyntax(name)}} {${this.processCommands(cmds)}}`;
+        // #alias {name} {commands} {group}
+        const parts = this.tokenize(args, ' ');
+        if (parts.length >= 2) {
+            const name = parts[0].trim().replace(/^{|}$/g, '');
+            let cmds = '';
+            let group = '';
+
+            if (parts[1].startsWith('{')) {
+                cmds = parts[1].replace(/^{|}$/g, '');
+                group = parts[2] ? parts[2].trim().replace(/^{|}$/g, '') : '';
+            } else {
+                // In JMC, if there are exactly 3 parts, the 3rd is likely the group.
+                if (parts.length === 3) {
+                    cmds = parts[1];
+                    group = parts[2].replace(/^{|}$/g, '');
+                } else {
+                    cmds = parts.slice(1).join(' ');
+                }
+            }
+
+            let out = '';
+            if (group) out += `#CLASS {${group}} {OPEN}\n`;
+            out += `#ALIAS {${this.convertSyntax(name)}} {${this.processCommands(cmds)}}`;
+            if (group) out += `\n#CLASS {${group}} {CLOSE}`;
+            return out;
         }
         return `#ALIAS {${this.convertSyntax(args)}}`;
     }
 
     convertActionJMC(args) {
-        // #action {pattern} {commands} {priority}
+        // #action {pattern} {commands} {priority} {group}
         const parts = this.tokenize(args, ' ');
         if (parts.length >= 2) {
-            const pattern = parts[0].trim().replace(/^{|}$/g, '');
-            const cmds = parts[1].trim().replace(/^{|}$/g, '');
-            const priority = parts[2] ? parts[2].trim().replace(/^{|}$/g, '') : '';
-            let out = `#ACTION {${this.convertSyntax(pattern)}} {${this.processCommands(cmds)}}`;
+            let patternToken = parts[0].trim();
+            let startIndex = 0;
+
+            // Special case: JMC sometimes has "TEXT" as first argument for type
+            if (patternToken.toUpperCase() === 'TEXT' && parts.length >= 3) {
+                patternToken = parts[1].trim();
+                startIndex = 1;
+            }
+
+            let pattern = patternToken.replace(/^{|}$/g, '');
+            let cmds = '';
+            let priority = '';
+            let group = '';
+
+            const cmdsToken = parts[startIndex + 1];
+            if (cmdsToken.startsWith('{')) {
+                cmds = cmdsToken.replace(/^{|}$/g, '');
+                priority = parts[startIndex + 2] ? parts[startIndex + 2].trim().replace(/^{|}$/g, '') : '';
+                group = parts[startIndex + 3] ? parts[startIndex + 3].trim().replace(/^{|}$/g, '') : '';
+            } else {
+                // If not in braces, check for priority as next token
+                if (parts.length > startIndex + 2 && /^\d+$/.test(parts[startIndex + 2])) {
+                    cmds = cmdsToken;
+                    priority = parts[startIndex + 2];
+                    group = parts[startIndex + 3] ? parts[startIndex + 3].trim().replace(/^{|}$/g, '') : '';
+                } else {
+                    cmds = parts.slice(startIndex + 1).join(' ');
+                }
+            }
+
+            let out = '';
+            if (group) out += `#CLASS {${group}} {OPEN}\n`;
+            out += `#ACTION {${this.convertSyntax(pattern)}} {${this.processCommands(cmds)}}`;
             if (priority) out += ` {${priority}}`;
+            if (group) out += `\n#CLASS {${group}} {CLOSE}`;
             return out;
         }
         return `#ACTION {${this.convertSyntax(args)}}`;
@@ -692,7 +1190,7 @@ export class TinTinConverter {
             }
             return out;
         }
-        return `#comment UNCONVERTED JMC IF: #if ${args}`;
+        return `#NOP UNCONVERTED JMC IF: #if ${args}`;
     }
 
     convertMathJMC(args) {
@@ -703,7 +1201,7 @@ export class TinTinConverter {
             const expr = match[2].trim().replace(/^{|}$/g, '');
             return `#math {${name}} {${this.convertSyntax(expr)}}`;
         }
-        return `#comment UNCONVERTED JMC MATH: #math ${args}`;
+        return `#NOP UNCONVERTED JMC MATH: #math ${args}`;
     }
 
     convertGroupJMC(args) {
@@ -717,18 +1215,40 @@ export class TinTinConverter {
             if (op === 'list') return `#CLASS`;
             if (op === 'delete') return `#CLASS {${label}} {KILL}`;
         }
-        return `#comment JMC GROUP COMMAND: #group ${args}`;
+        return `#NOP JMC GROUP COMMAND: #group ${args}`;
     }
 
     convertHighlightJMC(args) {
-        // #highlight {color} {pattern}
-        const match = args.match(/^{([^}]+)}\s*{(.*)}$/s) || args.match(/^(\S+)\s+(.*)$/s);
-        if (match) {
-            const color = match[1].trim().replace(/^{|}$/g, '');
-            const pattern = match[2].trim().replace(/^{|}$/g, '');
-            return `#HIGHLIGHT {${this.convertSyntax(pattern)}} {${color}}`;
+        // #highlight {color} {pattern} {group}
+        const parts = this.tokenize(args, ' ');
+        if (parts.length >= 2) {
+            const color = parts[0].trim().replace(/^{|}$/g, '');
+            let patternToken = parts[1].trim();
+            let group = '';
+
+            let pattern = patternToken.replace(/^{|}$/g, '');
+
+            // Special compatibility: strip #showme from patterns as it's common in some scripts
+            // but likely intended to match the output of showme.
+            if (pattern.startsWith('#showme ')) {
+                pattern = pattern.substring(8).trim();
+            }
+
+            if (patternToken.startsWith('{')) {
+                group = parts[2] ? parts[2].trim().replace(/^{|}$/g, '') : '';
+            } else {
+                if (parts.length === 3) {
+                    group = parts[2].trim().replace(/^{|}$/g, '');
+                }
+            }
+
+            let out = '';
+            if (group) out += `#CLASS {${group}} {OPEN}\n`;
+            out += `#HIGHLIGHT {${this.convertSyntax(pattern)}} {${color}}`;
+            if (group) out += `\n#CLASS {${group}} {CLOSE}`;
+            return out;
         }
-        return `#comment UNCONVERTED JMC HIGHLIGHT: #highlight ${args}`;
+        return `#NOP UNCONVERTED JMC HIGHLIGHT: #highlight ${args}`;
     }
 
     convertGagJMC(args) {
@@ -746,19 +1266,32 @@ export class TinTinConverter {
             const replacement = match[2].trim().replace(/^{|}$/g, '');
             return `#SUBSTITUTE {${this.convertSyntax(pattern)}} {${this.convertSyntax(replacement)}}`;
         }
-        return `#comment UNCONVERTED JMC SUB: #sub ${args}`;
+        return `#NOP UNCONVERTED JMC SUB: #sub ${args}`;
     }
 
     convertHotkeyJMC(args) {
         // #hotkey {key} {commands} {group}
-        const match = args.match(/^{([^}]+)}\s*{(.*)}(?:\s*{(.*)})?/s);
-        if (match) {
-            const key = match[1].trim();
-            const cmds = match[2].trim();
+        const parts = this.tokenize(args, ' ');
+        if (parts.length >= 2) {
+            const key = parts[0].trim().replace(/^{|}$/g, '');
+            let cmds = parts[1].trim();
+            let group = '';
+
+            if (cmds.startsWith('{')) {
+                cmds = cmds.replace(/^{|}$/g, '');
+                group = parts[2] ? parts[2].trim().replace(/^{|}$/g, '') : '';
+            } else {
+                cmds = parts.slice(1).join(' ');
+            }
+
             // TinTin++ uses #MACRO for hotkeys. Key names might need mapping, but keeping as is for now.
-            return `#MACRO {${key}} {${this.processCommands(cmds)}}`;
+            let out = '';
+            if (group) out += `#CLASS {${group}} {OPEN}\n`;
+            out += `#MACRO {${key}} {${this.processCommands(cmds)}}`;
+            if (group) out += `\n#CLASS {${group}} {CLOSE}`;
+            return out;
         }
-        return `#comment UNCONVERTED JMC HOTKEY: #hotkey ${args}`;
+        return `#NOP UNCONVERTED JMC HOTKEY: #hotkey ${args}`;
     }
 
     convertLoopJMC(args) {
@@ -772,7 +1305,7 @@ export class TinTinConverter {
             const processed = this.processCommands(cmds.replace(/%0/g, '___V_VAR___'));
             return `#LOOP {${from}} {${to}} {v} {${processed.replace(/___V_VAR___/g, '$v')}}`;
         }
-        return `#COMMENT UNCONVERTED JMC LOOP: #loop ${args}`;
+        return `#NOP UNCONVERTED JMC LOOP: #loop ${args}`;
     }
 
     convertToLowerJMC(args) {
@@ -783,7 +1316,7 @@ export class TinTinConverter {
             const text = match[2].trim().replace(/^{|}$/g, '');
             return `#FORMAT {${varName}} {%l} {${this.convertSyntax(text)}}`;
         }
-        return `#COMMENT UNCONVERTED JMC TOLOWER: #tolower ${args}`;
+        return `#NOP UNCONVERTED JMC TOLOWER: #tolower ${args}`;
     }
 
     convertToUpperJMC(args) {
@@ -793,56 +1326,23 @@ export class TinTinConverter {
             const text = match[2].trim().replace(/^{|}$/g, '');
             return `#FORMAT {${varName}} {%u} {${this.convertSyntax(text)}}`;
         }
-        return `#COMMENT UNCONVERTED JMC TOUPPER: #toupper ${args}`;
+        return `#NOP UNCONVERTED JMC TOUPPER: #toupper ${args}`;
     }
 
     convert(inputScript) {
         if (!inputScript) return '';
-        const lines = inputScript.split(/\r?\n/);
-        const outputLines = [];
-        let buffer = '';
-        let braceLevel = 0;
 
-        outputLines.push('#CLASS {converted} {OPEN}');
-
-        for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-
-            if (line.trim().endsWith('\\') && this.mode === 'powwow') {
-                buffer += (buffer ? '\n' : '') + line.trim().slice(0, -1);
-                continue;
-            }
-
-            buffer += (buffer ? '\n' : '') + line;
-
-            braceLevel += (line.match(/{/g) || []).length;
-            braceLevel -= (line.match(/}/g) || []).length;
-
-            if (braceLevel <= 0) {
-                const trimmed = buffer.trim();
-                if (trimmed === '') {
-                    outputLines.push('');
-                } else if (trimmed.startsWith('//') || (this.mode === 'jmc' && trimmed.startsWith('##'))) {
-                    const commentText = trimmed.substring(2);
-                    outputLines.push(`#COMMENT ${commentText.trim()}`);
-                } else if (trimmed.startsWith('/*')) {
-                    outputLines.push(`#COMMENT ${trimmed.replace(/\/\*|\*\//g, '').trim()}`);
-                } else if (trimmed.startsWith('#')) {
-                    outputLines.push(this.convertSingleCommand(trimmed));
-                } else {
-                    outputLines.push(this.convertSyntax(trimmed));
-                }
-                buffer = '';
-                braceLevel = 0;
-            }
+        // Handle line continuation for Lexer
+        let script = inputScript;
+        if (this.mode === 'powwow') {
+            script = script.replace(/\\\r?\n/g, '');
         }
 
-        if (buffer.trim()) {
-             outputLines.push(this.convertSingleCommand(buffer.trim()));
-        }
+        const lexer = new Lexer(script, { mode: this.mode, separator: this.separator });
+        const parser = new Parser(lexer);
+        const ast = parser.parse();
 
-        outputLines.push('#CLASS {converted} {CLOSE}');
-
-        return outputLines.join('\n');
+        const generator = new TinTinGenerator(this);
+        return generator.generate(ast);
     }
 }

--- a/tests/converter.test.js
+++ b/tests/converter.test.js
@@ -27,7 +27,7 @@ describe('TinTinConverter - Powwow Mode', () => {
   it('respects #option +autoprint', () => {
     const input = '#option +autoprint\n#action ^You parry.=say Nice parry!';
     const output = converter.convert(input);
-    expect(output).toContain('#COMMENT OPTION autoprint set to ON');
+    expect(output).toContain('#NOP OPTION autoprint set to ON');
     expect(output).toContain('#ACTION {^You parry.} {say Nice parry!}');
     expect(output).not.toContain('#LINE GAG');
   });
@@ -64,8 +64,7 @@ describe('TinTinConverter - Powwow Mode', () => {
 
     expect(output).toContain('#CLASS {autoloot} {OPEN}');
     expect(output).toContain('#ALIAS {loot+}');
-    expect(output).toContain('#MATH {powwow_at_loot_timer} {timer}');
-    expect(output).not.toContain('$p_p_at');
+    expect(output).toContain('#MATH {powwow_at_loot_timer} {@powwow_timer{}}');
   });
 
   it('handles Powwow alias with minus suffix and label', () => {
@@ -84,7 +83,7 @@ describe('TinTinConverter - Powwow Mode', () => {
   });
 
   it('converts Powwow #setvar, #mark, #hilite', () => {
-    expect(converter.convert('#setvar timer=100')).toContain('#VARIABLE {p_timer} {100}');
+    expect(converter.convert('#setvar timer=100')).toContain('#VARIABLE {powwow_at_timer} {100}');
     expect(converter.convert('#mark {Dragon}=bold red')).toContain('#HIGHLIGHT {{Dragon}} {bold red}');
     expect(converter.convert('#hilite inverse')).toContain('#HIGHLIGHT {.*} {inverse}');
     expect(converter.convert('#beep')).toContain('#BELL');
@@ -184,8 +183,8 @@ describe('TinTinConverter - JMC Mode', () => {
 
     const output = converter.convert(input);
 
-    expect(output).toContain('#COMMENT this is a JMC comment with hash');
-    expect(output).toContain('#COMMENT this is a JMC comment with slashes');
+    expect(output).toContain('#NOP this is a JMC comment with hash');
+    expect(output).toContain('#NOP this is a JMC comment with slashes');
   });
 
   it('converts JMC hotkeys', () => {

--- a/tests/converter.test.js
+++ b/tests/converter.test.js
@@ -24,12 +24,22 @@ describe('TinTinConverter - Powwow Mode', () => {
     expect(output).not.toContain('#LINE GAG');
   });
 
-  it('respects #option +autoprint', () => {
-    const input = '#option +autoprint\n#action ^You parry.=say Nice parry!';
-    const output = converter.convert(input);
-    expect(output).toContain('#NOP OPTION autoprint set to ON');
-    expect(output).toContain('#ACTION {^You parry.} {say Nice parry!}');
-    expect(output).not.toContain('#LINE GAG');
+  it('respects #option +/-autoprint', () => {
+    const inputEnable = '#option +autoprint\n#action ^You parry.=say Nice parry!';
+    const outputEnable = converter.convert(inputEnable);
+
+    // Enabling autoprint: keep the action, do not gag, and use #NOP instead of legacy #COMMENT
+    expect(outputEnable).toContain('#NOP OPTION autoprint set to ON');
+    expect(outputEnable).toContain('#ACTION {^You parry.} {say Nice parry!}');
+    expect(outputEnable).not.toContain('#LINE GAG');
+    expect(outputEnable).not.toContain('#COMMENT OPTION autoprint set to ON');
+
+    const inputDisable = '#option -autoprint\n#action ^You parry.=say Nice parry!';
+    const outputDisable = converter.convert(inputDisable);
+
+    // Disabling autoprint: gagging should be restored and legacy #COMMENT should not appear
+    expect(outputDisable).toContain('#LINE GAG');
+    expect(outputDisable).not.toContain('#COMMENT OPTION autoprint set to ON');
   });
 
   it('handles custom separator', () => {
@@ -83,7 +93,17 @@ describe('TinTinConverter - Powwow Mode', () => {
   });
 
   it('converts Powwow #setvar, #mark, #hilite', () => {
+    // special Powwow keywords mapped to powwow_at_*
     expect(converter.convert('#setvar timer=100')).toContain('#VARIABLE {powwow_at_timer} {100}');
+    expect(converter.convert('#setvar map=foo')).toContain('#VARIABLE {powwow_at_map} {foo}');
+    expect(converter.convert('#setvar prompt=Your prompt> ')).toContain('#VARIABLE {powwow_at_prompt} {Your prompt>}');
+    expect(converter.convert('#setvar lines=50')).toContain('#VARIABLE {powwow_at_lines} {50}');
+    expect(converter.convert('#setvar mem=high')).toContain('#VARIABLE {powwow_at_mem} {high}');
+
+    // string vs numeric expression: #VARIABLE for strings, #MATH for numeric expressions
+    expect(converter.convert('#setvar myvar="string value"')).toContain('#VARIABLE {p_myvar} {"string value"}');
+    expect(converter.convert('#setvar myvar=(1+2)')).toContain('#MATH {p_myvar} {1+2}');
+
     expect(converter.convert('#mark {Dragon}=bold red')).toContain('#HIGHLIGHT {{Dragon}} {bold red}');
     expect(converter.convert('#hilite inverse')).toContain('#HIGHLIGHT {.*} {inverse}');
     expect(converter.convert('#beep')).toContain('#BELL');
@@ -91,6 +111,15 @@ describe('TinTinConverter - Powwow Mode', () => {
     expect(converter.convert('#save my.tin')).toContain('#WRITE {my.tin}');
     expect(converter.convert('#load my.tin')).toContain('#READ {my.tin}');
     expect(converter.convert('#! ls')).toContain('#SYSTEM {ls}');
+  });
+
+  it('converts Powwow #bind with sequence and label', () => {
+    // Basic bind
+    expect(converter.convert('#bind f1=score')).toContain('#MACRO {f1} {score}');
+    // Bind with sequence
+    const output = converter.convert('#bind f1 ^[OP=score');
+    expect(output).toContain('#NOP ORIGINAL BIND LABEL: f1');
+    expect(output).toContain('#MACRO {^[OP} {score}');
   });
 });
 
@@ -179,12 +208,25 @@ describe('TinTinConverter - JMC Mode', () => {
     const input = [
       '## this is a JMC comment with hash',
       '// this is a JMC comment with slashes',
+      '/* this is a block comment */',
+      '/* multi-line',
+      '   block comment */',
+      '#alias {test} {',
+      '  /* nested comment */',
+      '  say hello',
+      '}',
+      '#action {pattern} {cmd} /* trailing comment */'
     ].join('\n');
 
     const output = converter.convert(input);
 
     expect(output).toContain('#NOP this is a JMC comment with hash');
     expect(output).toContain('#NOP this is a JMC comment with slashes');
+    expect(output).toContain('#NOP this is a block comment');
+    expect(output).toContain('#NOP multi-line');
+    expect(output).toContain('#NOP block comment');
+    expect(output).toContain('#NOP nested comment');
+    expect(output).toContain('#NOP trailing comment');
   });
 
   it('converts JMC hotkeys', () => {

--- a/tests/elvenrunes.test.js
+++ b/tests/elvenrunes.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { TinTinConverter } from '../src/converter.js';
+
+describe('Real-world scripts from elvenrunes.com', () => {
+  const pwConverter = new TinTinConverter({ mode: 'powwow' });
+  const jmcConverter = new TinTinConverter({ mode: 'jmc' });
+
+  it('converts Sìn\'s teleport system for Powwow', () => {
+    const input = '#alias tel={#(@-10=0);#($-11=\\$1);kremsub1;#if (\\@-10!=0) cast n \'teleport\' ${key_$0}; #else #print ("%% " +attr "yellow" + "Location not found. Locate first"+noattr)}';
+    const output = pwConverter.convert(input);
+    expect(output).toContain('#MATH {powwow_at_m10} {0}');
+    expect(output).toContain('#MATH {powwow_dollar_m11} {%%1}');
+    expect(output).toContain('#IF {$powwow_at_m10 != 0}');
+    expect(output).toContain('cast n \'teleport\' $p_key_%0');
+  });
+
+  it('converts Axel\'s XP counter for Powwow', () => {
+    const input = '#al xpcalc={#var $gainxp=($1-@oldxp);#var $gaintp=($2-@oldtp);#if (@oldxp==0) {#var $gainxp=0;#var $sessxp=0};#if (@oldtp==0) {#var $gaintp=0;#var $sesstp=0};#var $sessxp=((%($sessxp))+(%($gainxp)));#var $sesstp=((%($sesstp))+(%($gaintp)));#var @oldxp=$1;#var @oldtp=$2}';
+    const output = pwConverter.convert(input);
+    expect(output).toContain('#MATH {p_gainxp} {%1-$powwow_at_oldxp}');
+    expect(output).toContain('#MATH {p_sessxp}');
+    expect(output).toContain('#VARIABLE {powwow_at_oldxp} {%1}');
+  });
+
+  it('converts PowTTY XP counter (uses #sep and ANSI)', () => {
+    const input = '#sep ;\n#var $xpcal=0\n#var $bgr=\\033[32\\;1m\n#ac >+xp1 XPCOUNTER: &1 &2 &3 &4.={#if ($xpcal=="1") {xpcalc $1 $2\\;#var $xpcal=0}\\;xpprint $1 $2 $3 $4}';
+    const output = pwConverter.convert(input);
+    expect(output).toContain('#NOP SEPARATOR set to ;');
+    expect(output).toContain('#VARIABLE {p_xpcal} {0}');
+    expect(output).toContain('#ACTION {XPCOUNTER: %1 %2 %3 %4.}');
+  });
+
+  it('converts Antar\'s Grouping for JMC', () => {
+    const input = '#Alias {%2 raises her hand.} {group %2}';
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#ALIAS {%2 raises her hand.} {group %2}');
+  });
+
+  it('converts Antar\'s Reporting for JMC', () => {
+    const input = '#Alias {%0 hits, %1 mana, and %2 moves.} {#alias report emote has %0 hps, %1 mana, and %2 moves.}';
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#ALIAS {%0 hits, %1 mana, and %2 moves.} {#ALIAS {report} {emote has %0 hps, %1 mana, and %2 moves.}}');
+  });
+});

--- a/tests/yllemo.test.js
+++ b/tests/yllemo.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { TinTinConverter } from '../src/converter.js';
+
+describe('Real-world scripts from mume.yllemo.com', () => {
+  const jmcConverter = new TinTinConverter({ mode: 'jmc' });
+
+  it('converts JMC Set 1 configurations', () => {
+    const input = [
+      '#message alias OFF',
+      '#message action OFF',
+      '#presub on',
+      '#echo off',
+      '#ignore off',
+      '#speedwalk off',
+      '#verbat off',
+      '#colon leave',
+      '#NOP #',
+    ].join('\n');
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#CONFIG {VERBOSE} {OFF}');
+    expect(output).toContain('#NOP JMC PRESUB ON');
+    expect(output).toContain('#IGNORE {off}');
+    expect(output).toContain('#CONFIG {SPEEDWALK} {OFF}');
+    expect(output).toContain('#CONFIG {VERBATIM} {OFF}');
+    expect(output).toContain('#NOP JMC COLON: #colon leave');
+    expect(output).toContain('#NOP JMC NOP: #');
+  });
+
+  it('converts JMC Set 1 aliases and actions', () => {
+    const input = [
+      '#alias {.a} {stand;cast \'armour\';rest;wait} {default}',
+      '#action TEXT {^You bleed from open wounds.} {#var wound Wounds|ssb} {5} {default}',
+    ].join('\n');
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#ALIAS {.a} {stand; cast \'armour\'; rest; wait}');
+    expect(output).toContain('#CLASS {default} {OPEN}');
+    expect(output).toContain('#ACTION {^You bleed from open wounds.} {#VARIABLE {j_wound} {Wounds|ssb}} {5}');
+  });
+
+  it('converts JMC Set 1 variables and highlights', () => {
+    const input = [
+      '#variable {target} {dwarf}',
+      '#highlight {green} {#showme Thanks for playing!!!} {default}',
+    ].join('\n');
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#VARIABLE {j_target} {dwarf}');
+    expect(output).toContain('#CLASS {default} {OPEN}');
+    expect(output).toContain('#HIGHLIGHT {Thanks for playing!!!} {green}');
+  });
+
+  it('converts JMC Set 1 substitutions and hotkeys', () => {
+    const input = [
+      '#substitute {found} {FOUND}',
+      '#hot {ESC} {panic} {default}',
+    ].join('\n');
+    const output = jmcConverter.convert(input);
+    expect(output).toContain('#SUBSTITUTE {found} {FOUND}');
+    expect(output).toContain('#CLASS {default} {OPEN}');
+    expect(output).toContain('#MACRO {ESC} {panic}');
+  });
+});


### PR DESCRIPTION
I have significantly improved the TinTin++ Script Converter's compatibility by transitioning to a full Lexer/Parser architecture and implementing specialized handling for legacy scripts found on elvenrunes.com and mume.yllemo.com.

### Key Architectural Improvements:
- **Lexer/Parser Architecture:** Replaced brittle regex-based conversion with a robust tokenization and AST parsing system. This allows the converter to perfectly handle nested commands (e.g., `#alias` containing an `#if` which contains an `#action`) which previously caused the converter to break.
- **Powwow Compatibility Layer:** Converted scripts now include a preamble of TinTin++ functions (`@powwow_timer{}`, `@powwow_rand{}`, etc.) that emulate legacy internal behavior, ensuring complex math and timing logic works without manual adjustment.
- **Advanced Semantic Translation:** Added support for Powwow's unique string and list operators (word/char count, indexing, slicing) and special internal keywords like `timer`, `map`, and `prompt`.
- **Enhanced JMC Support:** Implemented 5-part `#action` syntax and improved parsing of groups and priorities when not wrapped in braces.

### Verification:
- **Comprehensive Testing:** Added 53 unit and E2E tests, including two new test suites (`tests/elvenrunes.test.js` and `tests/yllemo.test.js`) populated with real-world script snippets from the requested URLs.
- **Visual Verification:** Used Playwright to verify the frontend UI behavior and confirmed that deeply nested conversions are rendered correctly in real-time.
- **Code Review:** Incorporated expert feedback to use standard TinTin++ function prefixes (`@`) and non-functional comments (`#NOP`).

---
*PR created automatically by Jules for task [2991660186808118889](https://jules.google.com/task/2991660186808118889) started by @nschimme*

## Summary by Sourcery

Adopt a lexer/parser-based conversion pipeline for TinTin++ script conversion to better support complex Powwow and JMC scripts and improve compatibility with legacy real-world scripts.

New Features:
- Introduce dedicated Lexer, Parser, and TinTinGenerator components to tokenize scripts, build an AST, and generate TinTin++ output with a Powwow compatibility preamble.
- Add Powwow-specific emulation functions and keyword handling (e.g., timer, map, prompt, list and string operators) to preserve legacy script semantics.
- Extend JMC command coverage including group-aware aliases, actions, highlights, hotkeys, and additional shorthand variants (e.g., unali, unac, hot).

Enhancements:
- Refine Powwow and JMC variable and parameter translation to better distinguish special variables, arrays, and math expressions while reducing incorrect renaming.
- Improve control-flow conversion for Powwow (#if, #while, #for) to correctly parse nested blocks and #else branches using structural block extraction instead of regex.
- Switch converter-generated comments and unsupported constructs from functional #COMMENT to non-functional #NOP markers for safer output.
- Enhance prompt, bind, mark, and reset handling to map more closely onto TinTin++ constructs like #PROMPT, #MACRO, and fine-grained reset commands.

Tests:
- Update existing converter tests for the new behavior and comments, and add new suites with real-world Powwow scripts (elvenrunes and yllemo) to validate complex, nested conversion scenarios.